### PR TITLE
Proxy headers by whitelist. Fix error handling issue

### DIFF
--- a/ras_backstage/controllers/controller.py
+++ b/ras_backstage/controllers/controller.py
@@ -8,6 +8,12 @@ from ras_backstage.controllers.error_decorator import translate_exceptions
 log = get_logger()
 
 
+PROXY_HEADERS_WHITELIST = [
+    'Accept',
+    'Authorization'
+]
+
+
 def build_url(service_name, config, proxy_path):
     template = '{}://{}:{}/{}'
     try:
@@ -45,9 +51,11 @@ def proxy_request(request, service, url):
     # then turn list values of length 1 into scalars
     params = {k: v[0] if len(v) == 1 else v for k, v in params.items()}
 
+    headers = {k: v for k, v in request.headers.items() if k in PROXY_HEADERS_WHITELIST}
+
     req = requests.request(method=request.method,
                            url=proxy_url,
-                           headers=request.headers,
+                           headers=headers,
                            stream=True,
                            data=request.data,
                            params=params)

--- a/ras_backstage/controllers/error_decorator.py
+++ b/ras_backstage/controllers/error_decorator.py
@@ -21,8 +21,7 @@ def translate_exceptions(f):
             log.error(e.to_dict())
             raise
         except HTTPError as e:
-            detail = e.response.json().get('detail', "No further detail.")
-            raise RasError([str(e), detail])
+            raise RasError([str(e)])
         except Exception as e:
             log.error(str(e))
             if current_app.config.feature.translate_exceptions:

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -152,7 +152,8 @@ class TestController(TestClient):
                 'port': '4321'
             }
         }
-        response = self.client.get('/backstage-api/v1/mock-service/a', headers={'bar': 'baz'})
+        response = self.client.get('/backstage-api/v1/mock-service/a',
+                                   headers={'bar': 'baz', 'Authorization': 'wibble'})
         self.assertEqual(response.status_code, 200)
 
         mock.request.assert_called_once()
@@ -160,7 +161,8 @@ class TestController(TestClient):
         self.assertIn('method', call_args)
         self.assertEqual(call_args['method'], 'GET')
         self.assertIn('headers', call_args)
-        self.assertEqual(call_args['headers'].get('bar'), 'baz')
+        self.assertEqual(call_args['headers'].get('Authorization'), 'wibble')
+        self.assertEqual(call_args['headers'].get('bar'), None)
 
     @patch('ras_backstage.controllers.controller.requests')
     def test_proxy_endpoint_proxies_downstream_errors(self, mock):


### PR DESCRIPTION
* Allows through the Accept and Authorization headers for purposes of secure message proxying.
* Correction to the error handler to correctly show downstream errors.