### PR TITLE
Defect70 cannot access secure messages list

### DIFF
--- a/ras_backstage/views/backstage_view.py
+++ b/ras_backstage/views/backstage_view.py
@@ -49,4 +49,4 @@ def sign_in():
 @backstage_view.route('/<string:service>/<path:url>', methods=PROXY_METHODS)
 def proxy(service, url):
     req = controller.proxy_request(current_app.config, request, service, url)
-    return Response(req.raw.stream(decode_content=False), content_type=req.headers['content-type'])
+    return Response(req.content, status=req.status_code, content_type=req.headers['content-type'])

--- a/ras_backstage/views/backstage_view.py
+++ b/ras_backstage/views/backstage_view.py
@@ -49,4 +49,4 @@ def sign_in():
 @backstage_view.route('/<string:service>/<path:url>', methods=PROXY_METHODS)
 def proxy(service, url):
     req = controller.proxy_request(current_app.config, request, service, url)
-    return Response(req.raw.data, content_type=req.headers['content-type'])
+    return Response(req.raw.stream(decode_content=False), content_type=req.headers['content-type'])

--- a/ras_backstage/views/backstage_view.py
+++ b/ras_backstage/views/backstage_view.py
@@ -49,4 +49,4 @@ def sign_in():
 @backstage_view.route('/<string:service>/<path:url>', methods=PROXY_METHODS)
 def proxy(service, url):
     req = controller.proxy_request(current_app.config, request, service, url)
-    return Response(stream_with_context(req.iter_content()), content_type=req.headers['content-type'])
+    return Response(req.raw.data, content_type=req.headers['content-type'])

--- a/ras_backstage/views/backstage_view.py
+++ b/ras_backstage/views/backstage_view.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, Response, stream_with_context, request, make_response, jsonify, current_app
+from flask import Blueprint, Response, request, make_response, jsonify, current_app
 from ras_common_utils.ras_error.ras_error import RasError
 from flask_httpauth import HTTPBasicAuth
 from werkzeug.exceptions import BadRequest

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -34,6 +34,10 @@ class TestController(TestClient):
 
     @patch('ras_backstage.controllers.controller.requests')
     def test_proxy_endpoint_proxies_a_get_request(self, mock):
+        response = MagicMock()
+        response.status_code = 200
+        mock.request.return_value = response
+
         self.app.config.dependency = {
             'mock-service': {
                 'scheme': 'httpx',
@@ -145,6 +149,9 @@ class TestController(TestClient):
 
     @patch('ras_backstage.controllers.controller.requests')
     def test_proxy_endpoint_proxies_headers(self, mock):
+        response = MagicMock()
+        response.status_code = 200
+        mock.request.return_value = response
         self.app.config.dependency = {
             'mock-service': {
                 'scheme': 'httpx',
@@ -247,6 +254,10 @@ class TestController(TestClient):
     @patch('ras_backstage.controllers.controller.jwt')
     @patch('ras_backstage.controllers.controller.datetime')
     def test_request_with_valid_jwt_is_proxied(self, mock_datetime, mock_jwt, mock_requests):
+        response = MagicMock()
+        response.status_code = 200
+        mock_requests.request.return_value = response
+
         self.app.config.feature = {'validate_jwt': True}
         mock_datetime.now.return_value = 100
         mock_datetime.fromtimestamp = lambda x: x
@@ -278,6 +289,10 @@ class TestController(TestClient):
     @patch('ras_backstage.controllers.controller.jwt')
     @patch('ras_backstage.controllers.controller.datetime')
     def test_request_with_expired_jwt_still_returns_successfully(self, mock_datetime, mock_jwt, mock_requests):
+        response = MagicMock()
+        response.status_code = 200
+        mock_requests.request.return_value = response
+
         self.app.config.feature = {'validate_jwt': True}
         mock_datetime.now.return_value = 124
         mock_datetime.fromtimestamp = lambda x: x


### PR DESCRIPTION
The previous method of streaming request was causing backstage service to timeout which is why secure messages were not being loaded. 

https://trello.com/c/XZj7TICs/721-defect-70-p1-internal-staff-cannot-access-the-list-view-of-secure-messaging-from-rops