### PR TITLE
Us002b view collection exercises

### DIFF
--- a/config.py
+++ b/config.py
@@ -31,6 +31,15 @@ class Config(object):
                                                         RAS_SECURE_MESSAGING_SERVICE_HOST,
                                                         RAS_SECURE_MESSAGING_SERVICE_PORT)
 
+    RM_COLLECTION_EXERCISE_SERVICE_HOST = os.getenv('RM_COLLECTION_EXERCISE_SERVICE_HOST',
+                                                    'localhost')
+    RM_COLLECTION_EXERCISE_SERVICE_PORT = os.getenv('RM_COLLECTION_EXERCISE_SERVICE_PORT', 8080)
+    RM_COLLECTION_EXERCISE_SERVICE_PROTOCOL = os.getenv('RM_COLLECTION_EXERCISE_SERVICE_PROTOCOL',
+                                                        'http')
+    RM_COLLECTION_EXERCISE_SERVICE = '{}://{}:{}/'.format(RM_COLLECTION_EXERCISE_SERVICE_PROTOCOL,
+                                                          RM_COLLECTION_EXERCISE_SERVICE_HOST,
+                                                          RM_COLLECTION_EXERCISE_SERVICE_PORT)
+
     RM_SURVEY_SERVICE_HOST = os.getenv('RM_SURVEY_SERVICE_HOST', 'localhost')
     RM_SURVEY_SERVICE_PORT = os.getenv('RM_SURVEY_SERVICE_PORT', 8080)
     RM_SURVEY_SERVICE_PROTOCOL = os.getenv('RM_SURVEY_SERVICE_PROTOCOL', 'http')

--- a/ras_backstage/__init__.py
+++ b/ras_backstage/__init__.py
@@ -6,6 +6,7 @@ from flask_restplus import Api, Namespace
 
 from ras_backstage.logger_config import logger_initial_config
 
+
 app = Flask(__name__)
 
 app_config = 'config.{}'.format(os.environ.get('APP_SETTINGS', 'Config'))
@@ -37,6 +38,7 @@ from ras_backstage.resources.secure_messaging.update_label import RemoveUnreadLa
 from ras_backstage.resources.secure_messaging.send_message import SendMessage  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.secure_messaging.save_draft import SaveDraft  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.survey.get_survey_list import GetSurveyList  # NOQA # pylint: disable=wrong-import-position
+from ras_backstage.resources.survey.get_survey_by_short_name import GetSurveyByShortName  # NOQA # pylint: disable=wrong-import-position
 
 
 api.init_app(app)

--- a/ras_backstage/controllers/collection_exercise_controller.py
+++ b/ras_backstage/controllers/collection_exercise_controller.py
@@ -1,0 +1,27 @@
+import json
+import logging
+
+from structlog import wrap_logger
+
+from ras_backstage import app
+from ras_backstage.common.requests_handler import request_handler
+from ras_backstage.exception.exceptions import ApiError
+
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+
+def get_collection_exercises_by_survey(survey_id):
+    logger.debug('Retrieving collection exercises', survey_id=survey_id)
+    url = f'{app.config["RM_COLLECTION_EXERCISE_SERVICE"]}collectionexercises/survey/{survey_id}'
+    response = request_handler('GET', url, auth=app.config['BASIC_AUTH'])
+
+    if response.status_code == 204:
+        logger.debug('No collection exercises', survey_id=survey_id)
+        return []
+    if response.status_code != 200:
+        logger.error('Error retrieving collection exercises', survey_id=survey_id)
+        raise ApiError(url, response.status_code)
+
+    logger.debug('Successfully retrieved collection exercises', survey_id=survey_id)
+    return json.loads(response.text)

--- a/ras_backstage/controllers/survey_controller.py
+++ b/ras_backstage/controllers/survey_controller.py
@@ -13,7 +13,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 def get_survey_list():
     logger.debug('Retrieving survey list')
-    url = '{}{}'.format(app.config['RM_SURVEY_SERVICE'], 'surveys')
+    url = f'{app.config["RM_SURVEY_SERVICE"]}surveys'
     response = request_handler('GET', url, auth=app.config['BASIC_AUTH'])
 
     if response.status_code == 204:
@@ -24,4 +24,17 @@ def get_survey_list():
         raise ApiError(url, response.status_code)
 
     logger.debug('Successfully retrieved the survey list')
+    return json.loads(response.text)
+
+
+def get_survey_by_shortname(short_name):
+    logger.debug('Retrieving survey', short_name=short_name)
+    url = f'{app.config["RM_SURVEY_SERVICE"]}surveys/shortname/{short_name}'
+    response = request_handler('GET', url, auth=app.config['BASIC_AUTH'])
+
+    if response.status_code != 200:
+        logger.error('Error retrieving survey', short_name=short_name)
+        raise ApiError(url, response.status_code)
+
+    logger.debug('Successfully retrieved survey', short_name=short_name)
     return json.loads(response.text)

--- a/ras_backstage/error_handlers.py
+++ b/ras_backstage/error_handlers.py
@@ -14,14 +14,14 @@ logger = wrap_logger(logging.getLogger(__name__))
 @app.errorhandler(ApiError)
 @api.errorhandler(ApiError)
 def api_error_method(error):
+    status_code = error.status_code if error.status_code else 500
     error_json = {
         "error": {
             "url": error.url,
-            "status_code": error.status_code,
+            "status_code": status_code,
             "data": error.data
         }
     }
-    status_code = error.status_code if error.status_code else 500
     logger.error('Error during api call', url=error.url, status_code=error.status_code)
     return jsonify(error_json), status_code
 

--- a/ras_backstage/resources/survey/get_survey_by_short_name.py
+++ b/ras_backstage/resources/survey/get_survey_by_short_name.py
@@ -1,0 +1,24 @@
+import logging
+
+from flask import jsonify, make_response
+from flask_restplus import Resource
+from structlog import wrap_logger
+
+from ras_backstage import survey_api
+from ras_backstage.controllers import survey_controller
+
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+
+@survey_api.route('/shortname/<string:short_name>')
+class GetSurveyByShortName(Resource):
+
+    @staticmethod
+    def get(short_name):
+        logger.info('Retrieving survey', short_name=short_name)
+
+        survey = survey_controller.get_survey_by_shortname(short_name)
+
+        logger.info('Successfully retrieved survey', short_name=short_name)
+        return make_response(jsonify(survey), 200)

--- a/ras_backstage/resources/survey/get_survey_by_short_name.py
+++ b/ras_backstage/resources/survey/get_survey_by_short_name.py
@@ -5,7 +5,7 @@ from flask_restplus import Resource
 from structlog import wrap_logger
 
 from ras_backstage import survey_api
-from ras_backstage.controllers import survey_controller
+from ras_backstage.controllers import collection_exercise_controller, survey_controller
 
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -19,6 +19,9 @@ class GetSurveyByShortName(Resource):
         logger.info('Retrieving survey', short_name=short_name)
 
         survey = survey_controller.get_survey_by_shortname(short_name)
+        collection_exercises = collection_exercise_controller.get_collection_exercises_by_survey(survey['id'])
 
-        logger.info('Successfully retrieved survey', short_name=short_name)
-        return make_response(jsonify(survey), 200)
+        response_json = {"survey": survey, "collection_exercises": collection_exercises}
+
+        logger.info('Successfully retrieved survey', survey_id=survey['id'], short_name=short_name)
+        return make_response(jsonify(response_json), 200)

--- a/ras_backstage/resources/survey/get_survey_by_short_name.py
+++ b/ras_backstage/resources/survey/get_survey_by_short_name.py
@@ -19,9 +19,9 @@ class GetSurveyByShortName(Resource):
         logger.info('Retrieving survey', short_name=short_name)
 
         survey = survey_controller.get_survey_by_shortname(short_name)
-        collection_exercises = collection_exercise_controller.get_collection_exercises_by_survey(survey['id'])
+        ce_list = collection_exercise_controller.get_collection_exercises_by_survey(survey['id'])
 
-        response_json = {"survey": survey, "collection_exercises": collection_exercises}
+        response_json = {"survey": survey, "collection_exercises": ce_list}
 
         logger.info('Successfully retrieved survey', survey_id=survey['id'], short_name=short_name)
         return make_response(jsonify(response_json), 200)

--- a/test/resources/test_survey.py
+++ b/test/resources/test_survey.py
@@ -10,6 +10,8 @@ url_get_survey_list = f'{app.config["RM_SURVEY_SERVICE"]}surveys'
 with open('test/test_data/survey/survey_list.json') as json_data:
     survey_list = json.load(json_data)
 url_get_survey_by_short_name = f'{app.config["RM_SURVEY_SERVICE"]}surveys/shortname/bres'
+url_get_collection_exercises = f'{app.config["RM_COLLECTION_EXERCISE_SERVICE"]}' \
+                               'collectionexercises/survey/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
 
 
 class TestSurvey(unittest.TestCase):
@@ -22,6 +24,13 @@ class TestSurvey(unittest.TestCase):
             "shortName": "BRES",
             "surveyRef": "221"
         }
+        self.collection_exercises = [
+            {
+                "id": "c6467711-21eb-4e78-804c-1db8392f93fb",
+                "name": "201601",
+                "scheduledExecutionDateTime": "2017-05-15T00:00:00Z"
+            }
+        ]
 
     @requests_mock.mock()
     def test_get_survey_list(self, mock_request):
@@ -64,6 +73,7 @@ class TestSurvey(unittest.TestCase):
     @requests_mock.mock()
     def test_get_survey_by_short_name(self, mock_request):
         mock_request.get(url_get_survey_by_short_name, json=self.survey)
+        mock_request.get(url_get_collection_exercises, json=self.collection_exercises)
 
         response = self.app.get('/backstage-api/v1/survey/shortname/bres')
 
@@ -71,10 +81,21 @@ class TestSurvey(unittest.TestCase):
         self.assertIn('"id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"'.encode(), response.data)
         self.assertIn('"longName": "Business Register and Employment Survey"'.encode(),
                       response.data)
+        self.assertIn('"name": "201601"'.encode(), response.data)
 
     @requests_mock.mock()
-    def test_get_survey_by_short_name_fail(self, mock_request):
+    def test_get_survey_by_short_name_survey_fail(self, mock_request):
         mock_request.get(url_get_survey_by_short_name, status_code=500)
+
+        response = self.app.get('/backstage-api/v1/survey/shortname/bres')
+
+        self.assertEqual(response.status_code, 500)
+        self.assertIn('"status_code": 500'.encode(), response.data)
+
+    @requests_mock.mock()
+    def test_get_survey_by_short_name_ce_fail(self, mock_request):
+        mock_request.get(url_get_survey_by_short_name, json=self.survey)
+        mock_request.get(url_get_collection_exercises, status_code=500)
 
         response = self.app.get('/backstage-api/v1/survey/shortname/bres')
 

--- a/test/resources/test_survey.py
+++ b/test/resources/test_survey.py
@@ -6,15 +6,22 @@ import requests_mock
 from ras_backstage import app
 
 
-url_get_survey_list = '{}{}'.format(app.config['RM_SURVEY_SERVICE'], 'surveys')
+url_get_survey_list = f'{app.config["RM_SURVEY_SERVICE"]}surveys'
 with open('test/test_data/survey/survey_list.json') as json_data:
     survey_list = json.load(json_data)
+url_get_survey_by_short_name = f'{app.config["RM_SURVEY_SERVICE"]}surveys/shortname/bres'
 
 
 class TestSurvey(unittest.TestCase):
 
     def setUp(self):
         self.app = app.test_client()
+        self.survey = {
+            "id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
+            "longName": "Business Register and Employment Survey",
+            "shortName": "BRES",
+            "surveyRef": "221"
+        }
 
     @requests_mock.mock()
     def test_get_survey_list(self, mock_request):
@@ -53,3 +60,23 @@ class TestSurvey(unittest.TestCase):
         self.assertEqual(response.status_code, 500)
         self.assertIn('"json": "aaaa"'.encode(), response.data)
         self.assertIn('"message": "Expecting value"'.encode(), response.data)
+
+    @requests_mock.mock()
+    def test_get_survey_by_short_name(self, mock_request):
+        mock_request.get(url_get_survey_by_short_name, json=self.survey)
+
+        response = self.app.get('/backstage-api/v1/survey/shortname/bres')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('"id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"'.encode(), response.data)
+        self.assertIn('"longName": "Business Register and Employment Survey"'.encode(),
+                      response.data)
+
+    @requests_mock.mock()
+    def test_get_survey_by_short_name_fail(self, mock_request):
+        mock_request.get(url_get_survey_by_short_name, status_code=500)
+
+        response = self.app.get('/backstage-api/v1/survey/shortname/bres')
+
+        self.assertEqual(response.status_code, 500)
+        self.assertIn('"status_code": 500'.encode(), response.data)


### PR DESCRIPTION
Added endpoint to return the data required for the single survey view page in the internal UI.

This includes survey data (short/longName, surveyRef and legalBasis(not yet implemented))
This also includes a list of collection exercises information

[trello](https://trello.com/c/TZoUzqkn/24-us002b-view-collection-exercises-13pts)