### PR TITLE
Fix/update abbreviation formatting

### DIFF
--- a/ras_backstage/common/mappers.py
+++ b/ras_backstage/common/mappers.py
@@ -2,5 +2,4 @@ import re
 
 
 def format_short_name(short_name):
-    short_name = re.sub('(&)', r' \1 ', short_name)
-    return short_name
+    return re.sub('(&)', r' \1 ', short_name)

--- a/ras_backstage/common/mappers.py
+++ b/ras_backstage/common/mappers.py
@@ -1,0 +1,7 @@
+import re
+
+
+def format_short_name(short_name):
+    short_name = short_name.upper()
+    short_name = re.sub('(&)', r' \1 ', short_name)
+    return short_name

--- a/ras_backstage/common/mappers.py
+++ b/ras_backstage/common/mappers.py
@@ -2,6 +2,5 @@ import re
 
 
 def format_short_name(short_name):
-    short_name = short_name.upper()
     short_name = re.sub('(&)', r' \1 ', short_name)
     return short_name

--- a/ras_backstage/resources/survey/get_survey_by_short_name.py
+++ b/ras_backstage/resources/survey/get_survey_by_short_name.py
@@ -5,6 +5,7 @@ from flask_restplus import Resource
 from structlog import wrap_logger
 
 from ras_backstage import survey_api
+from ras_backstage.common.mappers import format_short_name
 from ras_backstage.controllers import collection_exercise_controller, survey_controller
 
 
@@ -19,6 +20,9 @@ class GetSurveyByShortName(Resource):
         logger.info('Retrieving survey', short_name=short_name)
 
         survey = survey_controller.get_survey_by_shortname(short_name)
+        # Format survey shortName
+        survey['shortName'] = format_short_name(survey['shortName'])
+
         ce_list = collection_exercise_controller.get_collection_exercises_by_survey(survey['id'])
 
         response_json = {"survey": survey, "collection_exercises": ce_list}

--- a/ras_backstage/resources/survey/get_survey_list.py
+++ b/ras_backstage/resources/survey/get_survey_list.py
@@ -5,6 +5,7 @@ from flask_restplus import Resource
 from structlog import wrap_logger
 
 from ras_backstage import survey_api
+from ras_backstage.common.mappers import format_short_name
 from ras_backstage.controllers import survey_controller
 
 
@@ -19,6 +20,10 @@ class GetSurveyList(Resource):
         logger.info('Retrieving survey list')
 
         survey_list = survey_controller.get_survey_list()
+
+        # Format survey shortName
+        for survey in survey_list:
+            survey['shortName'] = format_short_name(survey['shortName'])
 
         logger.info('Successfully retrieved survey list')
         return make_response(jsonify(survey_list), 200)


### PR DESCRIPTION
Adding spaces to either side of `&` characters in survey abbreviations which contain them.
i.e. `Sand&Gravel` -> `Sand & Gravel`