### PR TITLE
US007 view collection instruments - Add GET from backstage to collection instrument

### DIFF
--- a/ras_backstage/controllers/collection_instrument_controller.py
+++ b/ras_backstage/controllers/collection_instrument_controller.py
@@ -5,6 +5,7 @@ from structlog import wrap_logger
 
 from ras_backstage import app
 from ras_backstage.common.requests_handler import request_handler
+from ras_backstage.exception.exceptions import ApiError
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -25,3 +26,27 @@ def upload_collection_instrument(survey_id, collection_exercise_id, file):
 
     logger.debug('Successfully uploaded collection instrument',
                  collection_exercise_id=collection_exercise_id)
+
+
+def get_collection_instruments_by_classifier(survey_id, collection_exercise_id):
+    logger.debug('Retrieving collection instruments', survey_id=survey_id,
+                 collection_exercise_id=collection_exercise_id)
+    url = f'{app.config["RAS_COLLECTION_INSTRUMENT_SERVICE"]}' \
+          f'collection-instrument-api/1.0.2/collectioninstrument'
+
+    classifiers = {}
+    if survey_id:
+        classifiers['SURVEY_ID'] = survey_id
+    if collection_exercise_id:
+        classifiers['COLLECTION_EXERCISE'] = collection_exercise_id
+
+    response = request_handler(url=url, method='GET', auth=app.config['BASIC_AUTH'],
+                               params={'searchString': json.dumps(classifiers)})
+
+    if response.status_code != 200:
+        logger.error('Error retrieving collection instruments')
+        raise ApiError(url, response.status_code)
+
+    logger.debug('Successfully retrieved collection instruments', survey_id=survey_id,
+                 collection_exercise_id=collection_exercise_id)
+    return json.loads(response.text)

--- a/ras_backstage/controllers/collection_instrument_controller.py
+++ b/ras_backstage/controllers/collection_instrument_controller.py
@@ -15,11 +15,7 @@ def upload_collection_instrument(survey_id, collection_exercise_id, file):
     url = f'{app.config["RAS_COLLECTION_INSTRUMENT_SERVICE"]}' \
           f'collection-instrument-api/1.0.2/upload/{collection_exercise_id}'
 
-    classifiers = {}
-    if survey_id:
-        classifiers['SURVEY_ID'] = survey_id
-    if collection_exercise_id:
-        classifiers['COLLECTION_EXERCISE'] = collection_exercise_id
+    classifiers = _build_classifiers(collection_exercise_id, survey_id)
 
     request_handler(url=url, method='POST', auth=app.config['BASIC_AUTH'], files={'file': file},
                     params={'classifiers': json.dumps(classifiers)})
@@ -34,11 +30,7 @@ def get_collection_instruments_by_classifier(survey_id, collection_exercise_id):
     url = f'{app.config["RAS_COLLECTION_INSTRUMENT_SERVICE"]}' \
           f'collection-instrument-api/1.0.2/collectioninstrument'
 
-    classifiers = {}
-    if survey_id:
-        classifiers['SURVEY_ID'] = survey_id
-    if collection_exercise_id:
-        classifiers['COLLECTION_EXERCISE'] = collection_exercise_id
+    classifiers = _build_classifiers(collection_exercise_id, survey_id)
 
     response = request_handler(url=url, method='GET', auth=app.config['BASIC_AUTH'],
                                params={'searchString': json.dumps(classifiers)})
@@ -50,3 +42,12 @@ def get_collection_instruments_by_classifier(survey_id, collection_exercise_id):
     logger.debug('Successfully retrieved collection instruments', survey_id=survey_id,
                  collection_exercise_id=collection_exercise_id)
     return json.loads(response.text)
+
+
+def _build_classifiers(collection_exercise_id, survey_id):
+    classifiers = {}
+    if survey_id:
+        classifiers['SURVEY_ID'] = survey_id
+    if collection_exercise_id:
+        classifiers['COLLECTION_EXERCISE'] = collection_exercise_id
+    return classifiers

--- a/ras_backstage/controllers/collection_instrument_controller.py
+++ b/ras_backstage/controllers/collection_instrument_controller.py
@@ -18,8 +18,12 @@ def upload_collection_instrument(survey_id, collection_exercise_id, file):
     classifiers = _build_classifiers(collection_exercise_id, survey_id)
 
     files = {"file": (file.filename, file.stream, file.mimetype)}
-    request_handler(url=url, method='POST', auth=app.config['BASIC_AUTH'], files=files,
-                    params={'classifiers': json.dumps(classifiers)})
+    response = request_handler(url=url, method='POST', auth=app.config['BASIC_AUTH'], files=files,
+                               params={'classifiers': json.dumps(classifiers)})
+
+    if response.status_code != 200:
+        logger.error('Error uploading collection instrument')
+        raise ApiError(url, response.status_code)
 
     logger.debug('Successfully uploaded collection instrument',
                  collection_exercise_id=collection_exercise_id)

--- a/ras_backstage/resources/collection_exercise/single_collection_exercise.py
+++ b/ras_backstage/resources/collection_exercise/single_collection_exercise.py
@@ -8,6 +8,7 @@ from ras_backstage import collection_exercise_api
 from ras_backstage.common.filters import get_collection_exercise_by_period
 from ras_backstage.common.mappers import format_short_name
 from ras_backstage.controllers import collection_exercise_controller, survey_controller
+from ras_backstage.controllers.collection_instrument_controller import get_collection_instruments_by_classifier
 
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -30,9 +31,12 @@ class GetSingleCollectionExercise(Resource):
             return make_response(jsonify({"message": "Collection exercise not found"}), 404)
         full_exercise = collection_exercise_controller.get_collection_exercise_by_id(exercise['id'])
 
+        collection_instruments = get_collection_instruments_by_classifier(survey['id'], exercise['id'])
+
         response_json = {
             "survey": survey,
-            "collection_exercise": full_exercise
+            "collection_exercise": full_exercise,
+            "collection_instruments": collection_instruments
         }
         logger.info('Successfully retrieved collection exercise details',
                     shortname=short_name, period=period)

--- a/ras_backstage/resources/collection_instrument/collection_instrument.py
+++ b/ras_backstage/resources/collection_instrument/collection_instrument.py
@@ -29,3 +29,16 @@ class CollectionInstrument(Resource):
                                                                       request.files['file'])
         logger.info('Successfully retrieved collection exercise details', shortname=short_name, period=period)
         return Response(status=201)
+
+
+    @staticmethod
+    def get(short_name, period):
+        logger.info('Retrieving collection instruments', short_name=short_name, period=period)
+
+        survey = survey_controller.get_survey_by_shortname(short_name)
+        exercises = collection_exercise_controller.get_collection_exercises_by_survey(survey['id'])
+        exercise = get_collection_exercise_by_period(exercises, period)
+        collection_instruments = collection_instrument_controller.get_collection_instruments_by_classifier(survey['id'], exercise['id'])
+
+        logger.info('Successfully retrieved collection instruments', short_name=short_name, period=period)
+        return make_response(jsonify(collection_instruments), 200)

--- a/ras_backstage/resources/collection_instrument/collection_instrument.py
+++ b/ras_backstage/resources/collection_instrument/collection_instrument.py
@@ -29,18 +29,3 @@ class CollectionInstrument(Resource):
         upload_collection_instrument(survey['id'], exercise['id'], request.files['file'])
         logger.info('Successfully retrieved collection exercise details', shortname=short_name, period=period)
         return Response(status=201)
-
-    @staticmethod
-    def get(short_name, period):
-        logger.info('Retrieving collection instruments', short_name=short_name, period=period)
-
-        survey = survey_controller.get_survey_by_shortname(short_name)
-        exercises = collection_exercise_controller.get_collection_exercises_by_survey(survey['id'])
-        # Find the collection exercise for the given period
-        exercise = get_collection_exercise_by_period(exercises, period)
-        if not exercise:
-            return make_response(jsonify({"message": "Collection exercise not found"}), 404)
-        collection_instruments = get_collection_instruments_by_classifier(survey['id'], exercise['id'])
-
-        logger.info('Successfully retrieved collection instruments', short_name=short_name, period=period)
-        return make_response(jsonify(collection_instruments), 200)

--- a/ras_backstage/resources/collection_instrument/collection_instrument.py
+++ b/ras_backstage/resources/collection_instrument/collection_instrument.py
@@ -7,8 +7,7 @@ from structlog import wrap_logger
 from ras_backstage import collection_instrument_api
 from ras_backstage.common.filters import get_collection_exercise_by_period
 from ras_backstage.controllers import survey_controller, collection_exercise_controller
-from ras_backstage.controllers.collection_instrument_controller import get_collection_instruments_by_classifier, \
-    upload_collection_instrument
+from ras_backstage.controllers.collection_instrument_controller import upload_collection_instrument
 
 logger = wrap_logger(logging.getLogger(__name__))
 

--- a/test/resources/test_collection_exercise.py
+++ b/test/resources/test_collection_exercise.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+from urllib.parse import urlencode
 
 import requests_mock
 
@@ -11,8 +12,18 @@ url_ces = f'{app.config["RM_COLLECTION_EXERCISE_SERVICE"]}' \
           'collectionexercises/survey/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
 url_ce = f'{app.config["RM_COLLECTION_EXERCISE_SERVICE"]}' \
          f'collectionexercises/e33daf0e-6a27-40cd-98dc-c6231f50e84a'
+url_get_collection_instrument = f'{app.config["RAS_COLLECTION_INSTRUMENT_SERVICE"]}' \
+                                   f'collection-instrument-api/1.0.2/collectioninstrument'
 with open('test/test_data/collection_exercise/collection_exercise.json') as json_data:
     collection_exercise = json.load(json_data)
+
+
+def _build_search_string():
+    classifiers = {
+        "SURVEY_ID": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
+        "COLLECTION_EXERCISE": "e33daf0e-6a27-40cd-98dc-c6231f50e84a"
+    }
+    return urlencode({'searchString': json.dumps(classifiers)})
 
 
 class TestCollectionExercise(unittest.TestCase):
@@ -37,16 +48,36 @@ class TestCollectionExercise(unittest.TestCase):
             "scheduledExecutionDateTime": "2017-08-12T00:00:00Z"
           }
         ]
+        self.collection_instruments = [
+            {
+                "classifiers": {
+                    "COLLECTION_EXERCISE": [
+                        "e33daf0e-6a27-40cd-98dc-c6231f50e84a"
+                    ],
+                    "RU_REF": [],
+                    "SURVEY_ID": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+                },
+                "file_name": "file",
+                "id": "f732afbe-c710-4c95-a8d3-6644833195a7",
+                "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+            }
+        ]
 
     @requests_mock.mock()
     def test_single_collection_exercise(self, mock_request):
+        # Given
         mock_request.get(url_get_survey_by_short_name, json=self.survey)
         mock_request.get(url_ces, json=self.collection_exercises)
         mock_request.get(url_ce, json=collection_exercise)
+        search_string = _build_search_string()
+        mock_request.get(f'{url_get_collection_instrument}?{search_string}', json=self.collection_instruments,
+                         complete_qs=True)
 
+        # When
         response = self.app.get("/backstage-api/v1/collection-exercise/test/000000")
         response_data = json.loads(response.data)
 
+        # Then
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response_data['survey']['longName'],
                          'Business Register and Employment Survey')
@@ -95,3 +126,37 @@ class TestCollectionExercise(unittest.TestCase):
 
         self.assertEqual(response.status_code, 500)
         self.assertEqual(response_data['error']['status_code'], 500)
+
+    @requests_mock.mock()
+    def test_get_collection_instrument(self, mock_request):
+        # Given
+        mock_request.get(url_get_survey_by_short_name, json=self.survey)
+        mock_request.get(url_ces, json=self.collection_exercises)
+        mock_request.get(url_ce, json=collection_exercise)
+        search_string = _build_search_string()
+        mock_request.get(f'{url_get_collection_instrument}?{search_string}', json=self.collection_instruments,
+                         complete_qs=True)
+
+        # When
+        response = self.app.get("/backstage-api/v1/collection-exercise/test/000000")
+        response_data = json.loads(response.data)
+
+        # Then
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_data['collection_instruments'], self.collection_instruments)
+
+    @requests_mock.mock()
+    def test_get_collection_instrument_returns_error(self, mock_request):
+        # Given
+        mock_request.get(url_get_survey_by_short_name, json=self.survey)
+        mock_request.get(url_ces, json=self.collection_exercises)
+        mock_request.get(url_ce, json=collection_exercise)
+        search_string = _build_search_string()
+        mock_request.get(f'{url_get_collection_instrument}?{search_string}',
+                         complete_qs=True, status_code=400)
+
+        # When
+        response = self.app.get('/backstage-api/v1/collection-exercise/test/000000')
+
+        # Then
+        self.assertEqual(response.status_code, 400)

--- a/test/resources/test_collection_instrument.py
+++ b/test/resources/test_collection_instrument.py
@@ -12,6 +12,8 @@ url_ces = f'{app.config["RM_COLLECTION_EXERCISE_SERVICE"]}' \
           'collectionexercises/survey/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
 url_upload_collection_instrument = f'{app.config["RAS_COLLECTION_INSTRUMENT_SERVICE"]}' \
                                    f'collection-instrument-api/1.0.2/upload/e33daf0e-6a27-40cd-98dc-c6231f50e84a'
+url_get_collection_instrument = f'{app.config["RAS_COLLECTION_INSTRUMENT_SERVICE"]}' \
+                                   f'collection-instrument-api/1.0.2/collectioninstrument'
 
 
 class TestCollectionExercise(unittest.TestCase):
@@ -25,16 +27,30 @@ class TestCollectionExercise(unittest.TestCase):
             "surveyRef": "221"
         }
         self.collection_exercises = [
-          {
-            "id": "c6467711-21eb-4e78-804c-1db8392f93fb",
-            "exerciseRef": "201601",
-            "scheduledExecutionDateTime": "2017-05-15T00:00:00Z"
-          },
-          {
-            "id": "e33daf0e-6a27-40cd-98dc-c6231f50e84a",
-            "exerciseRef": "000000",
-            "scheduledExecutionDateTime": "2017-08-12T00:00:00Z"
-          }
+            {
+                "id": "c6467711-21eb-4e78-804c-1db8392f93fb",
+                "exerciseRef": "201601",
+                "scheduledExecutionDateTime": "2017-05-15T00:00:00Z"
+            },
+            {
+                "id": "e33daf0e-6a27-40cd-98dc-c6231f50e84a",
+                "exerciseRef": "000000",
+                "scheduledExecutionDateTime": "2017-08-12T00:00:00Z"
+            }
+        ]
+        self.collection_instruments = [
+            {
+                "classifiers": {
+                    "COLLECTION_EXERCISE": [
+                        "e33daf0e-6a27-40cd-98dc-c6231f50e84a"
+                    ],
+                    "RU_REF": [],
+                    "SURVEY_ID": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+                },
+                "file_name": "file",
+                "id": "f732afbe-c710-4c95-a8d3-6644833195a7",
+                "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+            }
         ]
 
     @requests_mock.mock()
@@ -49,13 +65,12 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.post(f'{url_upload_collection_instrument}?{params}')
 
         response = self.app.post('/backstage-api/v1/collection-instrument/test/000000', data=dict(
-            file=(BytesIO(b'data'), 'test.xlsx'),
-        ), query_string={'classifiers': json.dumps(classifiers)})
+            file=(BytesIO(b'data'), 'test.xlsx')))
 
         self.assertEqual(response.status_code, 201)
 
     @requests_mock.mock()
-    def test_no_collection_instrument(self, mock_request):
+    def test_no_collection_instrument_file_uploaded(self, mock_request):
         mock_request.get(url_get_survey_by_short_name, json=self.survey)
         mock_request.get(url_ces, json=self.collection_exercises)
         mock_request.post(url_upload_collection_instrument)
@@ -65,7 +80,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
 
     @requests_mock.mock()
-    def test_no_collection_exercise(self, mock_request):
+    def test_collection_exercise_period_does_not_match(self, mock_request):
         mock_request.get(url_get_survey_by_short_name, json=self.survey)
         mock_request.get(url_ces, json=self.collection_exercises)
         mock_request.post(url_upload_collection_instrument)
@@ -73,3 +88,40 @@ class TestCollectionExercise(unittest.TestCase):
         response = self.app.post('/backstage-api/v1/collection-instrument/test/000001')
 
         self.assertEqual(response.status_code, 404)
+
+    @requests_mock.mock()
+    def test_get_collection_instrument(self, mock_request):
+        # Given
+        classifiers = {
+            "SURVEY_ID": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
+            "COLLECTION_EXERCISE": "e33daf0e-6a27-40cd-98dc-c6231f50e84a"
+        }
+        params = urlencode({'searchString': json.dumps(classifiers)})
+        mock_request.get(url_get_survey_by_short_name, json=self.survey)
+        mock_request.get(url_ces, json=self.collection_exercises)
+        mock_request.get(f'{url_get_collection_instrument}?{params}', json=self.collection_instruments)
+
+        # When
+        response = self.app.get('/backstage-api/v1/collection-instrument/test/000000')
+
+        # Then
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.data), self.collection_instruments)
+
+    @requests_mock.mock()
+    def test_get_collection_instrument_returns_error(self, mock_request):
+        # Given
+        classifiers = {
+            "SURVEY_ID": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
+            "COLLECTION_EXERCISE": "e33daf0e-6a27-40cd-98dc-c6231f50e84a"
+        }
+        params = urlencode({'searchString': json.dumps(classifiers)})
+        mock_request.get(url_get_survey_by_short_name, json=self.survey)
+        mock_request.get(url_ces, json=self.collection_exercises)
+        mock_request.get(f'{url_get_collection_instrument}?{params}', status_code=400)
+
+        # When
+        response = self.app.get('/backstage-api/v1/collection-instrument/test/000000')
+
+        # Then
+        self.assertEqual(response.status_code, 400)

--- a/test/resources/test_collection_instrument.py
+++ b/test/resources/test_collection_instrument.py
@@ -55,6 +55,20 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
 
     @requests_mock.mock()
+    def test_upload_collection_instrument_fail(self, mock_request):
+        # Given
+        mock_request.get(url_get_survey_by_short_name, json=self.survey)
+        mock_request.get(url_ces, json=self.collection_exercises)
+        mock_request.post(f'{url_upload_collection_instrument}', status_code=500)
+
+        # When
+        response = self.app.post('/backstage-api/v1/collection-instrument/test/000000', data=dict(
+            file=(BytesIO(b'data'), 'test.xlsx')))
+
+        # Then
+        self.assertEqual(response.status_code, 500)
+
+    @requests_mock.mock()
     def test_no_collection_instrument_file_uploaded(self, mock_request):
         mock_request.get(url_get_survey_by_short_name, json=self.survey)
         mock_request.get(url_ces, json=self.collection_exercises)
@@ -65,7 +79,7 @@ class TestCollectionExercise(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
 
     @requests_mock.mock()
-    def test_collection_exercise_period_does_not_match(self, mock_request):
+    def test_upload_ci_when_missing_collection_exercise_period(self, mock_request):
         mock_request.get(url_get_survey_by_short_name, json=self.survey)
         mock_request.get(url_ces, json=self.collection_exercises)
         mock_request.post(url_upload_collection_instrument)

--- a/test/resources/test_collection_instrument.py
+++ b/test/resources/test_collection_instrument.py
@@ -12,8 +12,6 @@ url_ces = f'{app.config["RM_COLLECTION_EXERCISE_SERVICE"]}' \
           'collectionexercises/survey/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
 url_upload_collection_instrument = f'{app.config["RAS_COLLECTION_INSTRUMENT_SERVICE"]}' \
                                    f'collection-instrument-api/1.0.2/upload/e33daf0e-6a27-40cd-98dc-c6231f50e84a'
-url_get_collection_instrument = f'{app.config["RAS_COLLECTION_INSTRUMENT_SERVICE"]}' \
-                                   f'collection-instrument-api/1.0.2/collectioninstrument'
 
 
 class TestCollectionExercise(unittest.TestCase):
@@ -36,20 +34,6 @@ class TestCollectionExercise(unittest.TestCase):
                 "id": "e33daf0e-6a27-40cd-98dc-c6231f50e84a",
                 "exerciseRef": "000000",
                 "scheduledExecutionDateTime": "2017-08-12T00:00:00Z"
-            }
-        ]
-        self.collection_instruments = [
-            {
-                "classifiers": {
-                    "COLLECTION_EXERCISE": [
-                        "e33daf0e-6a27-40cd-98dc-c6231f50e84a"
-                    ],
-                    "RU_REF": [],
-                    "SURVEY_ID": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
-                },
-                "file_name": "file",
-                "id": "f732afbe-c710-4c95-a8d3-6644833195a7",
-                "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
             }
         ]
 
@@ -88,40 +72,3 @@ class TestCollectionExercise(unittest.TestCase):
         response = self.app.post('/backstage-api/v1/collection-instrument/test/000001')
 
         self.assertEqual(response.status_code, 404)
-
-    @requests_mock.mock()
-    def test_get_collection_instrument(self, mock_request):
-        # Given
-        classifiers = {
-            "SURVEY_ID": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
-            "COLLECTION_EXERCISE": "e33daf0e-6a27-40cd-98dc-c6231f50e84a"
-        }
-        params = urlencode({'searchString': json.dumps(classifiers)})
-        mock_request.get(url_get_survey_by_short_name, json=self.survey)
-        mock_request.get(url_ces, json=self.collection_exercises)
-        mock_request.get(f'{url_get_collection_instrument}?{params}', json=self.collection_instruments)
-
-        # When
-        response = self.app.get('/backstage-api/v1/collection-instrument/test/000000')
-
-        # Then
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.data), self.collection_instruments)
-
-    @requests_mock.mock()
-    def test_get_collection_instrument_returns_error(self, mock_request):
-        # Given
-        classifiers = {
-            "SURVEY_ID": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
-            "COLLECTION_EXERCISE": "e33daf0e-6a27-40cd-98dc-c6231f50e84a"
-        }
-        params = urlencode({'searchString': json.dumps(classifiers)})
-        mock_request.get(url_get_survey_by_short_name, json=self.survey)
-        mock_request.get(url_ces, json=self.collection_exercises)
-        mock_request.get(f'{url_get_collection_instrument}?{params}', status_code=400)
-
-        # When
-        response = self.app.get('/backstage-api/v1/collection-instrument/test/000000')
-
-        # Then
-        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
**Scope**
Worked with @benjefferies to add `GET` method for `/<short_name>/<period>` to allow collection instruments to be retrieved by `SURVEY_ID` and `COLLECTION_EXERCISE`(id).

[Trello](https://trello.com/c/er2up3GB/33-us007-view-collection-instruments-25pts-l-5-days)
[Confluence](https://digitaleq.atlassian.net/wiki/spaces/RASB/pages/160563223/US007+View+Collection+Instruments+L)

**How to test**
1. Ensure at least one collection instrument is uploaded with classifiers for a `SURVEY_ID` and `COLLECTION_EXERCISE` (see: https://github.com/ONSdigital/ras-collection-instrument/pull/70)
2. Make a `GET` request to the end point. E.g.
`http://localhost:8001/backstage-api/v1/collection-instrument/test/201701`
3. Ensure you get the collection instrument(s) information returned. E.g.
```
[
    {
        "classifiers": {
            "COLLECTION_EXERCISE": [
                "6b9b170e-e63b-4551-8eca-a1ffcc2c71b0"
            ],
            "RU_REF": [],
            "SURVEY_ID": "38ddb720-5d32-44d0-ad30-eef529c937c1"
        },
        "file_name": "file",
        "id": "409b8093-9065-4574-9c27-9ef09b80cd5c",
        "surveyId": "38ddb720-5d32-44d0-ad30-eef529c937c1"
    }
]
```
