### PR TITLE
Remove unnecessary classifiers survey_id and collection_exercise_id

### DIFF
--- a/ras_backstage/controllers/collection_instrument_controller.py
+++ b/ras_backstage/controllers/collection_instrument_controller.py
@@ -26,16 +26,29 @@ def upload_collection_instrument(collection_exercise_id, file):
                  collection_exercise_id=collection_exercise_id)
 
 
-def get_collection_instruments_by_classifier(collection_exercise_id):
-    logger.debug('Retrieving collection instruments', collection_exercise_id=collection_exercise_id)
+def get_collection_instruments_by_classifier(survey_id, collection_exercise_id):
+    logger.debug('Retrieving collection instruments', survey_id=survey_id,
+                 collection_exercise_id=collection_exercise_id)
     url = f'{app.config["RAS_COLLECTION_INSTRUMENT_SERVICE"]}' \
           f'collection-instrument-api/1.0.2/collectioninstrument'
 
-    response = request_handler(url=url, method='GET', auth=app.config['BASIC_AUTH'])
+    classifiers = _build_classifiers(collection_exercise_id, survey_id)
+    response = request_handler(url=url, method='GET', auth=app.config['BASIC_AUTH'],
+                               params={'searchString': json.dumps(classifiers)})
 
     if response.status_code != 200:
         logger.error('Error retrieving collection instruments')
         raise ApiError(url, response.status_code)
 
-    logger.debug('Successfully retrieved collection instruments', collection_exercise_id=collection_exercise_id)
+    logger.debug('Successfully retrieved collection instruments', survey_id=survey_id,
+                 collection_exercise_id=collection_exercise_id)
     return json.loads(response.text)
+
+
+def _build_classifiers(collection_exercise_id, survey_id):
+    classifiers = {}
+    if survey_id:
+        classifiers['SURVEY_ID'] = survey_id
+    if collection_exercise_id:
+        classifiers['COLLECTION_EXERCISE'] = collection_exercise_id
+    return classifiers

--- a/ras_backstage/controllers/collection_instrument_controller.py
+++ b/ras_backstage/controllers/collection_instrument_controller.py
@@ -10,16 +10,13 @@ from ras_backstage.exception.exceptions import ApiError
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-def upload_collection_instrument(survey_id, collection_exercise_id, file):
-    logger.debug('Uploading collection instrument', collection_exercise_id=collection_exercise_id, survey_id=survey_id)
+def upload_collection_instrument(collection_exercise_id, file):
+    logger.debug('Uploading collection instrument', collection_exercise_id=collection_exercise_id)
     url = f'{app.config["RAS_COLLECTION_INSTRUMENT_SERVICE"]}' \
           f'collection-instrument-api/1.0.2/upload/{collection_exercise_id}'
 
-    classifiers = _build_classifiers(collection_exercise_id, survey_id)
-
     files = {"file": (file.filename, file.stream, file.mimetype)}
-    response = request_handler(url=url, method='POST', auth=app.config['BASIC_AUTH'], files=files,
-                               params={'classifiers': json.dumps(classifiers)})
+    response = request_handler(url=url, method='POST', auth=app.config['BASIC_AUTH'], files=files)
 
     if response.status_code != 200:
         logger.error('Error uploading collection instrument')
@@ -29,30 +26,16 @@ def upload_collection_instrument(survey_id, collection_exercise_id, file):
                  collection_exercise_id=collection_exercise_id)
 
 
-def get_collection_instruments_by_classifier(survey_id, collection_exercise_id):
-    logger.debug('Retrieving collection instruments', survey_id=survey_id,
-                 collection_exercise_id=collection_exercise_id)
+def get_collection_instruments_by_classifier(collection_exercise_id):
+    logger.debug('Retrieving collection instruments', collection_exercise_id=collection_exercise_id)
     url = f'{app.config["RAS_COLLECTION_INSTRUMENT_SERVICE"]}' \
           f'collection-instrument-api/1.0.2/collectioninstrument'
 
-    classifiers = _build_classifiers(collection_exercise_id, survey_id)
-
-    response = request_handler(url=url, method='GET', auth=app.config['BASIC_AUTH'],
-                               params={'searchString': json.dumps(classifiers)})
+    response = request_handler(url=url, method='GET', auth=app.config['BASIC_AUTH'])
 
     if response.status_code != 200:
         logger.error('Error retrieving collection instruments')
         raise ApiError(url, response.status_code)
 
-    logger.debug('Successfully retrieved collection instruments', survey_id=survey_id,
-                 collection_exercise_id=collection_exercise_id)
+    logger.debug('Successfully retrieved collection instruments', collection_exercise_id=collection_exercise_id)
     return json.loads(response.text)
-
-
-def _build_classifiers(collection_exercise_id, survey_id):
-    classifiers = {}
-    if survey_id:
-        classifiers['SURVEY_ID'] = survey_id
-    if collection_exercise_id:
-        classifiers['COLLECTION_EXERCISE'] = collection_exercise_id
-    return classifiers

--- a/ras_backstage/resources/collection_exercise/single_collection_exercise.py
+++ b/ras_backstage/resources/collection_exercise/single_collection_exercise.py
@@ -33,7 +33,7 @@ class GetSingleCollectionExercise(Resource):
 
         exercise_events = collection_exercise_controller.get_collection_exercise_events(exercise['id'])
 
-        collection_instruments = get_collection_instruments_by_classifier(exercise['id'])
+        collection_instruments = get_collection_instruments_by_classifier(survey['id'], exercise['id'])
 
         summary_id = collection_exercise_controller.get_linked_sample_summary_id(exercise['id'])
         sample_summary = sample_controller.get_sample_summary(summary_id) if summary_id else None

--- a/ras_backstage/resources/collection_exercise/single_collection_exercise.py
+++ b/ras_backstage/resources/collection_exercise/single_collection_exercise.py
@@ -33,7 +33,7 @@ class GetSingleCollectionExercise(Resource):
 
         exercise_events = collection_exercise_controller.get_collection_exercise_events(exercise['id'])
 
-        collection_instruments = get_collection_instruments_by_classifier(survey['id'], exercise['id'])
+        collection_instruments = get_collection_instruments_by_classifier(exercise['id'])
 
         summary_id = collection_exercise_controller.get_linked_sample_summary_id(exercise['id'])
         sample_summary = sample_controller.get_sample_summary(summary_id) if summary_id else None

--- a/ras_backstage/resources/collection_instrument/collection_instrument.py
+++ b/ras_backstage/resources/collection_instrument/collection_instrument.py
@@ -30,7 +30,7 @@ class CollectionInstrument(Resource):
         if not exercise:
             return make_response(jsonify({"message": "Collection exercise not found"}), 404)
 
-        upload_collection_instrument(survey['id'], exercise['id'], request.files['file'])
+        upload_collection_instrument(exercise['id'], request.files['file'])
 
         logger.info('Successfully uploaded collection instrument', shortname=short_name, period=period)
         return Response(status=201)


### PR DESCRIPTION
Survey_id and Collection_exercise_id shouldn't be added to the classifiers JSON. They are already formed tables with data and relationships in collection instrument. By adding them into the classifiers table, we are not only causing duplication but also causing issues when a search is made with them. They need to be removed