### PR TITLE
Make hardcoded username and password configurable via the app config

### DIFF
--- a/config.py
+++ b/config.py
@@ -33,7 +33,8 @@ class Config(object):
 
     RM_COLLECTION_EXERCISE_SERVICE_HOST = os.getenv('RM_COLLECTION_EXERCISE_SERVICE_HOST',
                                                     'localhost')
-    RM_COLLECTION_EXERCISE_SERVICE_PORT = os.getenv('RM_COLLECTION_EXERCISE_SERVICE_PORT', 8145)
+    RM_COLLECTION_EXERCISE_SERVICE_PORT = os.getenv('RM_COLLECTION_EXERCISE_SERVICE_PORT',
+                                                    8145)
     RM_COLLECTION_EXERCISE_SERVICE_PROTOCOL = os.getenv('RM_COLLECTION_EXERCISE_SERVICE_PROTOCOL',
                                                         'http')
     RM_COLLECTION_EXERCISE_SERVICE = '{}://{}:{}/'.format(RM_COLLECTION_EXERCISE_SERVICE_PROTOCOL,
@@ -42,7 +43,8 @@ class Config(object):
 
     RAS_COLLECTION_INSTRUMENT_SERVICE_HOST = os.getenv('RAS_COLLECTION_INSTRUMENT_SERVICE_HOST',
                                                        'localhost')
-    RAS_COLLECTION_INSTRUMENT_SERVICE_PORT = os.getenv('RAS_COLLECTION_INSTRUMENT_SERVICE_PORT', 8002)
+    RAS_COLLECTION_INSTRUMENT_SERVICE_PORT = os.getenv('RAS_COLLECTION_INSTRUMENT_SERVICE_PORT',
+                                                       8002)
     RAS_COLLECTION_INSTRUMENT_SERVICE_PROTOCOL = os.getenv('RAS_COLLECTION_INSTRUMENT_SERVICE_PROTOCOL',
                                                            'http')
     RAS_COLLECTION_INSTRUMENT_SERVICE = '{}://{}:{}/'.format(RAS_COLLECTION_INSTRUMENT_SERVICE_PROTOCOL,
@@ -81,6 +83,10 @@ class DevelopmentConfig(Config):
     DJANGO_CLIENT_SECRET = os.getenv('DJANGO_CLIENT_SECRET', 'password')
     DJANGO_BASIC_AUTH = (DJANGO_CLIENT_ID, DJANGO_CLIENT_SECRET)
     JWT_SECRET = os.getenv('JWT_SECRET', 'testsecret')
+
+    # TODO: remove once UAA is implemented and use user supplied username/password
+    USERNAME = os.getenv('RAS_BACKSTAGE_USERNAME', 'user')
+    PASSWORD = os.getenv('RAS_BACKSTAGE_PASSWORD', 'pass')
 
 
 class TestingConfig(DevelopmentConfig):

--- a/ras_backstage/resources/sign_in/sign_in.py
+++ b/ras_backstage/resources/sign_in/sign_in.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 import logging
 
-from flask import request, make_response, jsonify
+from flask import current_app, request, make_response, jsonify
 from flask_restplus import fields, Resource
 from jose import jwt
 from structlog import wrap_logger
@@ -54,7 +54,7 @@ class SignInV2(Resource):
         password = message_json.get('password')
 
         # Obviously horrible, stopgap until uaa is implemented
-        if username == 'user' and password == 'pass':
+        if username == current_app.config['USERNAME'] and password == current_app.config['PASSWORD']:
             # We're assuming that uaa will return an Oauth2 token though it's almost certain that
             # this will change once we know exactly what is being returned.
             logger.info("Authentication successful", user=username)


### PR DESCRIPTION
In order to comply with security requirements, the username and password variables for logging in to the UAA stub are now configurable via the app's configuration. Default settings for Dev and Test config are still `user` and `pass`.