### PR TITLE
usxxx internal user sign in with uaa

### DIFF
--- a/config.py
+++ b/config.py
@@ -17,8 +17,8 @@ class Config(object):
     JWT_SECRET = os.getenv('JWT_SECRET')
 
     # TODO: remove once UAA is implemented and use user supplied username/password
-    USERNAME = os.getenv('RAS_BACKSTAGE_USERNAME', 'user')
-    PASSWORD = os.getenv('RAS_BACKSTAGE_PASSWORD', 'pass')
+    USERNAME = os.getenv('RAS_BACKSTAGE_USERNAME')
+    PASSWORD = os.getenv('RAS_BACKSTAGE_PASSWORD')
 
     RAS_OAUTH_SERVICE_HOST = os.getenv('RAS_OAUTH_SERVICE_HOST', 'localhost')
     RAS_OAUTH_SERVICE_PORT = os.getenv('RAS_OAUTH_SERVICE_PORT', 8040)
@@ -91,6 +91,8 @@ class DevelopmentConfig(Config):
     DJANGO_CLIENT_SECRET = os.getenv('DJANGO_CLIENT_SECRET', 'password')
     DJANGO_BASIC_AUTH = (DJANGO_CLIENT_ID, DJANGO_CLIENT_SECRET)
     JWT_SECRET = os.getenv('JWT_SECRET', 'testsecret')
+    USERNAME = os.getenv('RAS_BACKSTAGE_USERNAME', 'user')
+    PASSWORD = os.getenv('RAS_BACKSTAGE_PASSWORD', 'pass')
 
 
 class TestingConfig(DevelopmentConfig):

--- a/config.py
+++ b/config.py
@@ -79,7 +79,7 @@ class Config(object):
     UAA_SERVICE_URL = os.getenv('UAA_SERVICE_URL', 'localhost')
     UAA_CLIENT_ID = os.getenv('UAA_CLIENT_ID', 'ras_backstage_client_id')
     UAA_CLIENT_SECRET = os.getenv('UAA_CLIENT_SECRET', 'password')
-    USE_UAA = os.getenv('USE_UAA', default=True)
+    USE_UAA = os.getenv('USE_UAA', True)
 
 
 class DevelopmentConfig(Config):

--- a/config.py
+++ b/config.py
@@ -79,6 +79,7 @@ class Config(object):
     UAA_SERVICE_URL = os.getenv('UAA_SERVICE_URL', 'localhost')
     UAA_CLIENT_ID = os.getenv('UAA_CLIENT_ID', 'ras_backstage_client_id')
     UAA_CLIENT_SECRET = os.getenv('UAA_CLIENT_SECRET', 'password')
+    USE_UAA = os.getenv('USE_UAA', default=True)
 
 
 class DevelopmentConfig(Config):

--- a/config.py
+++ b/config.py
@@ -79,7 +79,7 @@ class Config(object):
     UAA_SERVICE_URL = os.getenv('UAA_SERVICE_URL', 'localhost')
     UAA_CLIENT_ID = os.getenv('UAA_CLIENT_ID', 'ras_backstage_client_id')
     UAA_CLIENT_SECRET = os.getenv('UAA_CLIENT_SECRET', 'password')
-    USE_UAA = os.getenv('USE_UAA', True)
+    USE_UAA = int(os.getenv('USE_UAA', 1))
 
 
 class DevelopmentConfig(Config):
@@ -99,3 +99,4 @@ class DevelopmentConfig(Config):
 class TestingConfig(DevelopmentConfig):
     DEBUG = True
     Testing = True
+    USE_UAA = 0

--- a/config.py
+++ b/config.py
@@ -76,6 +76,10 @@ class Config(object):
                                              RM_SAMPLE_SERVICE_HOST,
                                              RM_SAMPLE_SERVICE_PORT)
 
+    UAA_SERVICE_URL = os.getenv('UAA_SERVICE_URL', 'localhost')
+    UAA_CLIENT_ID = os.getenv('UAA_CLIENT_ID', 'ras_backstage_client_id')
+    UAA_CLIENT_SECRET = os.getenv('UAA_CLIENT_SECRET', 'password')
+
 
 class DevelopmentConfig(Config):
     DEBUG = os.getenv('DEBUG', True)

--- a/ras_backstage/controllers/uaa_controller.py
+++ b/ras_backstage/controllers/uaa_controller.py
@@ -1,0 +1,40 @@
+import json
+import logging
+
+from structlog import wrap_logger
+
+from ras_backstage import app
+from ras_backstage.common.requests_handler import request_handler
+from ras_backstage.exception.exceptions import ApiError
+
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+
+def sign_in(username, password):
+    logger.debug('Retrieving OAuth2 token for sign-in')
+    url = '{}{}'.format(app.config['UAA_SERVICE_URL'], '/oauth/token')
+    print(url)
+    data = {
+        'grant_type': 'password',
+        'client_id': app.config['UAA_CLIENT_ID'],
+        'client_secret': app.config['UAA_CLIENT_SECRET'],
+        'username': username,
+        'password': password,
+        'response_type': 'token',
+        'token_format': 'opaque'
+    }
+    print(data)
+    headers = {
+        'Accept': 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+    }
+    response = request_handler('POST', url, data=data, headers=headers)
+
+    if response.status_code != 200:
+        logger.error(f'Failed to retrieve OAuth2 token {response.text}')
+        raise ApiError(url, response.status_code)
+
+    oauth2_token = json.loads(response.text)
+    logger.debug('Successfully retrieved OAuth2 token')
+    return oauth2_token

--- a/ras_backstage/controllers/uaa_controller.py
+++ b/ras_backstage/controllers/uaa_controller.py
@@ -13,7 +13,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 def sign_in(username, password):
     logger.debug('Retrieving OAuth2 token for sign-in')
-    url = f"{app.config['UAA_SERVICE_URL']}{'/oauth/token'}",
+    url = f"{app.config['UAA_SERVICE_URL']}/oauth/token",
 
     data = {
         'grant_type': 'password',

--- a/ras_backstage/controllers/uaa_controller.py
+++ b/ras_backstage/controllers/uaa_controller.py
@@ -14,7 +14,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 def sign_in(username, password):
     logger.debug('Retrieving OAuth2 token for sign-in')
     url = '{}{}'.format(app.config['UAA_SERVICE_URL'], '/oauth/token')
-    print(url)
+
     data = {
         'grant_type': 'password',
         'client_id': app.config['UAA_CLIENT_ID'],
@@ -24,7 +24,7 @@ def sign_in(username, password):
         'response_type': 'token',
         'token_format': 'opaque'
     }
-    print(data)
+
     headers = {
         'Accept': 'application/json',
         'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',

--- a/ras_backstage/controllers/uaa_controller.py
+++ b/ras_backstage/controllers/uaa_controller.py
@@ -13,7 +13,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 def sign_in(username, password):
     logger.debug('Retrieving OAuth2 token for sign-in')
-    url = '{}{}'.format(app.config['UAA_SERVICE_URL'], '/oauth/token')
+    url = f"{app.config['UAA_SERVICE_URL']}{'/oauth/token'}",
 
     data = {
         'grant_type': 'password',

--- a/ras_backstage/resources/sign_in/sign_in.py
+++ b/ras_backstage/resources/sign_in/sign_in.py
@@ -7,7 +7,7 @@ from jose import jwt
 from structlog import wrap_logger
 
 from ras_backstage import app, sign_in_api, sign_in_api_v2
-from ras_backstage.controllers import django_controller
+from ras_backstage.controllers import django_controller, uaa_controller
 
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -53,12 +53,29 @@ class SignInV2(Resource):
         username = message_json.get('username')
         password = message_json.get('password')
 
-        # Obviously horrible, stopgap until uaa is implemented
-        if username == current_app.config['USERNAME'] and password == current_app.config['PASSWORD']:
-            # We're assuming that uaa will return an Oauth2 token though it's almost certain that
-            # this will change once we know exactly what is being returned.
-            logger.info("Authentication successful", user=username)
-            return make_response(jsonify({"token": "1234abc"}), 201)
+        if True:
+            if username == current_app.config['USERNAME'] and password == current_app.config['PASSWORD']:
+                # We're assuming that uaa will return an Oauth2 token though it's almost certain that
+                # this will change once we know exactly what is being returned.
+                logger.info("Authentication successful", user=username)
+                return make_response(jsonify({"token": "1234abc"}), 201)
+            else:
+                logger.info("Authentication failed", user=username)
+                return make_response(jsonify({"error": "Username and/or password incorrect"}), 401)
         else:
-            logger.info("Authentication failed", user=username)
-            return make_response(jsonify({"error": "Username and/or password incorrect"}), 401)
+            logger.info('Retrieving sign-in details')
+            message_json = request.get_json()
+            username = message_json.get('username')
+            password = message_json.get('password')
+
+            oauth2_token = uaa_controller.sign_in(username, password)
+            token_expiry = datetime.now() + timedelta(seconds=int(oauth2_token['expires_in']))
+            oauth2_token['expires_at'] = token_expiry.timestamp()
+            oauth2_token['party_id'] = 'BRES'
+            oauth2_token['role'] = 'internal'
+
+            jwt_secret = app.config['JWT_SECRET']
+            token = jwt.encode(oauth2_token, jwt_secret, algorithm=app.config['JWT_ALGORITHM'])
+
+            logger.info('Successfully retrieved sign-in details')
+            return make_response(jsonify({"token": token}), 201)

--- a/test/resources/test_collection_instrument.py
+++ b/test/resources/test_collection_instrument.py
@@ -1,7 +1,5 @@
-import json
 import unittest
 from io import BytesIO
-from urllib.parse import urlencode
 
 import requests_mock
 
@@ -39,14 +37,9 @@ class TestCollectionExercise(unittest.TestCase):
 
     @requests_mock.mock()
     def test_upload_collection_instrument(self, mock_request):
-        classifiers = {
-            "SURVEY_ID": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
-            "COLLECTION_EXERCISE": "e33daf0e-6a27-40cd-98dc-c6231f50e84a"
-        }
-        params = urlencode({'classifiers': json.dumps(classifiers)})
         mock_request.get(url_get_survey_by_short_name, json=self.survey)
         mock_request.get(url_ces, json=self.collection_exercises)
-        mock_request.post(f'{url_upload_collection_instrument}?{params}', complete_qs=True,
+        mock_request.post(f'{url_upload_collection_instrument}', complete_qs=True,
                           additional_matcher=self.file_matcher)
 
         response = self.app.post('/backstage-api/v1/collection-instrument/test/000000', data=dict(


### PR DESCRIPTION
This PR makes the use of UAA configurable via the app's environment. If USE_UAA is set in the app's environment then the app will attempt to use UAA to authenticate. This option is only in place to allow local dev to continue whilst a local UAA mock/docker solution is in place. In future iterations UAA will be the only authentication mechanism.