### PR TITLE
Specify stdout as the logging stream

### DIFF
--- a/ras_backstage/logger_config.py
+++ b/ras_backstage/logger_config.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 
 from structlog import configure
 from structlog.stdlib import add_log_level, filter_by_level
@@ -31,7 +32,7 @@ def logger_initial_config(service_name=None,
         event_dict['service'] = service_name
         return event_dict
 
-    logging.basicConfig(level=log_level, format=logger_format)
+    logging.basicConfig(stream=sys.stdout, level=log_level, format=logger_format)
     configure(processors=[add_log_level, filter_by_level, add_service, format_exc_info,
                           TimeStamper(fmt=logger_date_format, utc=True, key="created_at"),
                           JSONRenderer(indent=indent)])


### PR DESCRIPTION
Pass stream stdout to basic config for logging rather than default to stderr