### PR TITLE
add respondents for ru per survey

### DIFF
--- a/test/resources/test_reporting_units.py
+++ b/test/resources/test_reporting_units.py
@@ -13,7 +13,11 @@ url_get_party_by_ru_ref = f'{app.config["RAS_PARTY_SERVICE"]}party-api/v1/partie
 url_get_party_by_business_id = f'{app.config["RAS_PARTY_SERVICE"]}' \
                                f'party-api/v1/businesses/id/b3ba864b-7cbc-4f44-84fe-88dc018a1a4c'
 with open('test/test_data/party/business_party.json') as json_data:
-    party = json.load(json_data)
+    party_business = json.load(json_data)
+url_get_party_by_respondent_id = f'{app.config["RAS_PARTY_SERVICE"]}' \
+                               f'party-api/v1/respondents/id/cd592e0f-8d07-407b-b75d-e01fbdae8233'
+with open('test/test_data/party/business_party.json') as json_data:
+    party_respondent = json.load(json_data)
 url_get_cases_by_business_id = f'{app.config["RM_CASE_SERVICE"]}cases/partyid/b3ba864b-7cbc-4f44-84fe-88dc018a1a4c'
 with open('test/test_data/case/case_list.json') as json_data:
     case_list = json.load(json_data)
@@ -54,11 +58,12 @@ class TestReportingUnits(unittest.TestCase):
 
     @requests_mock.mock()
     def test_get_reporting_unit(self, mock_request):
-        mock_request.get(url_get_party_by_ru_ref, json=party)
+        mock_request.get(url_get_party_by_ru_ref, json=party_business)
         mock_request.get(url_get_survey_by_id, json=survey_list[0])
         mock_request.get(url_get_cases_by_business_id, json=case_list)
         mock_request.get(url_get_collection_exercise_by_survey, json=[collection_exercise])
-        mock_request.get(url_get_party_by_business_id, json=party)
+        mock_request.get(url_get_party_by_business_id, json=party_business)
+        mock_request.get(url_get_party_by_respondent_id, json=party_respondent)
 
         response = self.app.get("/backstage-api/v1/reporting-unit/12345")
         response_data = json.loads(response.data)
@@ -70,11 +75,12 @@ class TestReportingUnits(unittest.TestCase):
 
     @requests_mock.mock()
     def test_get_reporting_unit_no_cases(self, mock_request):
-        mock_request.get(url_get_party_by_ru_ref, json=party)
+        mock_request.get(url_get_party_by_ru_ref, json=party_business)
         mock_request.get(url_get_survey_by_id, json=survey_list[0])
         mock_request.get(url_get_cases_by_business_id, status_code=404)
         mock_request.get(url_get_collection_exercise_by_survey, json=[collection_exercise])
-        mock_request.get(url_get_party_by_business_id, json=party)
+        mock_request.get(url_get_party_by_business_id, json=party_business)
+        mock_request.get(url_get_party_by_respondent_id, json=party_respondent)
 
         response = self.app.get("/backstage-api/v1/reporting-unit/12345")
         response_data = json.loads(response.data)
@@ -94,7 +100,7 @@ class TestReportingUnits(unittest.TestCase):
 
     @requests_mock.mock()
     def test_get_reporting_unit_survey_fail(self, mock_request):
-        mock_request.get(url_get_party_by_ru_ref, json=party)
+        mock_request.get(url_get_party_by_ru_ref, json=party_business)
         mock_request.get(url_get_survey_by_id, status_code=500)
 
         response = self.app.get("/backstage-api/v1/reporting-unit/12345")
@@ -104,10 +110,23 @@ class TestReportingUnits(unittest.TestCase):
         self.assertEqual(response_data['error']['status_code'], 500)
 
     @requests_mock.mock()
+    def test_get_reporting_unit_respondent_fail(self, mock_request):
+        mock_request.get(url_get_party_by_ru_ref, json=party_business)
+        mock_request.get(url_get_survey_by_id, json=survey_list[0])
+        mock_request.get(url_get_party_by_respondent_id, status_code=500)
+
+        response = self.app.get("/backstage-api/v1/reporting-unit/12345")
+        response_data = json.loads(response.data)
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response_data['error']['status_code'], 500)
+
+    @requests_mock.mock()
     def test_get_reporting_unit_cases_fail(self, mock_request):
-        mock_request.get(url_get_party_by_ru_ref, json=party)
+        mock_request.get(url_get_party_by_ru_ref, json=party_business)
         mock_request.get(url_get_survey_by_id, json=survey_list[0])
         mock_request.get(url_get_cases_by_business_id, status_code=500)
+        mock_request.get(url_get_party_by_respondent_id, json=party_respondent)
 
         response = self.app.get("/backstage-api/v1/reporting-unit/12345")
         response_data = json.loads(response.data)
@@ -117,10 +136,11 @@ class TestReportingUnits(unittest.TestCase):
 
     @requests_mock.mock()
     def test_get_reporting_unit_collection_exercise_fail(self, mock_request):
-        mock_request.get(url_get_party_by_ru_ref, json=party)
+        mock_request.get(url_get_party_by_ru_ref, json=party_business)
         mock_request.get(url_get_survey_by_id, json=survey_list[0])
         mock_request.get(url_get_cases_by_business_id, json=case_list)
         mock_request.get(url_get_collection_exercise_by_survey, status_code=500)
+        mock_request.get(url_get_party_by_respondent_id, json=party_respondent)
 
         response = self.app.get("/backstage-api/v1/reporting-unit/12345")
         response_data = json.loads(response.data)
@@ -130,10 +150,11 @@ class TestReportingUnits(unittest.TestCase):
 
     @requests_mock.mock()
     def test_get_reporting_unit_party_id_fail(self, mock_request):
-        mock_request.get(url_get_party_by_ru_ref, json=party)
+        mock_request.get(url_get_party_by_ru_ref, json=party_business)
         mock_request.get(url_get_survey_by_id, json=survey_list[0])
         mock_request.get(url_get_cases_by_business_id, json=case_list)
         mock_request.get(url_get_collection_exercise_by_survey, json=[collection_exercise])
+        mock_request.get(url_get_party_by_respondent_id, json=party_respondent)
         mock_request.get(url_get_party_by_business_id, status_code=500)
 
         response = self.app.get("/backstage-api/v1/reporting-unit/12345")

--- a/test/test_data/party/respondent_party.json
+++ b/test/test_data/party/respondent_party.json
@@ -1,22 +1,22 @@
 {
-  "associations": [
-    {
-      "enrolments": [
+    "associations": [
         {
-          "enrolmentStatus": "ENABLED", 
-          "name": "Business Register and Employment Survey", 
-          "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+            "enrolments": [
+                {
+                    "enrolmentStatus": "ENABLED",
+                    "name": "Business Register and Employment Survey",
+                    "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+                }
+            ],
+            "partyId": "b3ba864b-7cbc-4f44-84fe-88dc018a1a4c",
+            "sampleUnitRef": "50012345678"
         }
-      ],
-      "partyId": "1216a88f-ee2a-420c-9e6a-ee34893c29cf",
-      "sampleUnitRef": "49900000004"
-    }
-  ], 
-  "emailAddress": "rhiannon.griffiths@ons.gov.uk",
-  "firstName": "Rhiannon",
-  "id": "07d672bc-497b-448f-a406-a20a7e6013d7",
-  "lastName": "Griffiths", 
-  "sampleUnitType": "BI", 
-  "status": "ACTIVE", 
-  "telephone": "01636 265626"
+    ],
+    "emailAddress": "Jacky.Turner@email.com",
+    "firstName": "Jacky",
+    "lastName": "Turner",
+    "telephone": "7971161859",
+    "id": "cd592e0f-8d07-407b-b75d-e01fbdae8233",
+    "sampleUnitType": "BI",
+    "status": "ACTIVE"
 }


### PR DESCRIPTION
As an: internal user
I need: to be able to view respondent data for a Reporting Unit for a specific survey
So that: I understand the relationships with respondents for the Reporting Unit across surveys