### PR TITLE
US045 Defect Fix

### DIFF
--- a/ras_backstage/controllers/collection_exercise_controller.py
+++ b/ras_backstage/controllers/collection_exercise_controller.py
@@ -39,6 +39,22 @@ def get_collection_exercises_by_survey(survey_id):
     return response.json()
 
 
+def get_collection_exercises_by_party_id(party_id):
+    logger.debug('Retrieving collection exercises', party_id=party_id)
+    url = f'{app.config["RM_COLLECTION_EXERCISE_SERVICE"]}collectionexercises/party/{party_id}'
+    response = request_handler('GET', url, auth=app.config['BASIC_AUTH'])
+
+    if response.status_code == 204:
+        logger.debug('No collection exercises', party_id=party_id)
+        return []
+    if response.status_code != 200:
+        logger.error('Error retrieving collection exercises', party_id=party_id)
+        raise ApiError(url, response.status_code)
+
+    logger.debug('Successfully retrieved collection exercises', party_id=party_id)
+    return response.json()
+
+
 def get_collection_exercise_events(collection_exercise_id):
     logger.debug('Retrieving collection exercise events', collection_exercise_id=collection_exercise_id)
     url = f'{app.config["RM_COLLECTION_EXERCISE_SERVICE"]}collectionexercises/{collection_exercise_id}/events'

--- a/ras_backstage/resources/reporting_units/get_reporting_unit.py
+++ b/ras_backstage/resources/reporting_units/get_reporting_unit.py
@@ -32,6 +32,7 @@ class GetReportingUnit(Resource):
                                 for collection_exercise in collection_exercises
                                 if parse_date(collection_exercise['scheduledStartDateTime']) < now]
 
+        # Add extra collection exercise data using data from case service
         cases = case_controller.get_cases_by_business_party_id(reporting_unit['id'])
         add_collection_exercise_details(collection_exercises, reporting_unit, cases)
 

--- a/ras_backstage/resources/reporting_units/get_reporting_unit.py
+++ b/ras_backstage/resources/reporting_units/get_reporting_unit.py
@@ -62,17 +62,13 @@ class GetReportingUnit(Resource):
 
         # Link respondents and surveys
         for respondent in respondents:
-            respondent_survey_id_and_status = []
             for association in respondent.get('associations'):
+                respondent.pop('associations', None)
                 for enrolment in association.get('enrolments'):
-                    respondent_survey_id_and_status.append(enrolment['surveyId'], )
-            for survey in surveys:
-                if survey['id'] in respondent_survey_ids:
-                    survey['respondents'].append(respondent)
-            respondent.pop('associations', None)
-
-
-
+                    respondent['enrolmentStatus'] = enrolment.get('enrolmentStatus')
+                    for survey in surveys:
+                        if survey['id'] == enrolment['surveyId'] and respondent not in survey['respondents']:
+                            survey['respondents'].append(respondent)
 
         response_json = {
             "reporting_unit": reporting_unit,

--- a/ras_backstage/resources/reporting_units/get_reporting_unit.py
+++ b/ras_backstage/resources/reporting_units/get_reporting_unit.py
@@ -50,7 +50,7 @@ class GetReportingUnit(Resource):
             survey['collection_exercises'] = [collection_exercise
                                               for collection_exercise in collection_exercises
                                               if survey['id'] == collection_exercise['surveyId']]
-            link_respondents_to_surveys(respondents, survey)
+            link_respondents_to_survey(respondents, survey)
 
         response_json = {
             "reporting_unit": reporting_unit,
@@ -68,7 +68,7 @@ def add_collection_exercise_details(collection_exercises, reporting_unit, cases)
         exercise['companyRegion'] = reporting_unit_ce['region']
 
 
-def link_respondents_to_surveys(respondents, survey):
+def link_respondents_to_survey(respondents, survey):
     survey['respondents'] = []
     for respondent in respondents:
         for association in respondent.get('associations'):

--- a/ras_backstage/resources/reporting_units/get_reporting_unit.py
+++ b/ras_backstage/resources/reporting_units/get_reporting_unit.py
@@ -74,7 +74,6 @@ def link_respondents_to_surveys(respondents, surveys):
         survey['respondents'] = []
         for respondent in respondents:
             for association in respondent.get('associations'):
-                respondent.pop('associations', None)
                 for enrolment in association.get('enrolments'):
                     respondent['enrolmentStatus'] = enrolment.get('enrolmentStatus')
                     if survey['id'] == enrolment['surveyId'] and respondent not in survey['respondents']:

--- a/ras_backstage/resources/reporting_units/get_reporting_unit.py
+++ b/ras_backstage/resources/reporting_units/get_reporting_unit.py
@@ -24,12 +24,12 @@ class GetReportingUnit(Resource):
 
         # Get all collection exercises for ru_ref
         reporting_unit = party_controller.get_party_by_ru_ref(ru_ref)
-        all_collection_exercises = collection_exercise_controller.get_collection_exercises_by_party_id(reporting_unit['id'])
+        collection_exercises = collection_exercise_controller.get_collection_exercises_by_party_id(reporting_unit['id'])
 
         # We only want collection exercises which are live
         now = datetime.now(timezone.utc)
         collection_exercises = [collection_exercise
-                                for collection_exercise in all_collection_exercises
+                                for collection_exercise in collection_exercises
                                 if parse_date(collection_exercise['scheduledStartDateTime']) < now]
 
         cases = case_controller.get_cases_by_business_party_id(reporting_unit['id'])

--- a/test/test_data/collection_exercise/collection_exercise_list.json
+++ b/test/test_data/collection_exercise/collection_exercise_list.json
@@ -1,0 +1,54 @@
+[
+  {
+    "id": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
+    "actualExecutionDateTime": "2017-11-10T12:14:41.768+0000",
+    "actualPublishDateTime": "2017-11-10T12:16:28.509+0000",
+    "caseTypes": [
+      {
+        "actionPlanId": "e71002ac-3575-47eb-b87f-cd9db92bf9a6",
+        "sampleUnitType": "B"
+      },
+      {
+        "actionPlanId": "0009e978-0932-463b-a2a1-b45cb3ffcb2a",
+        "sampleUnitType": "BI"
+      }
+    ],
+    "executedBy": null,
+    "exerciseRef": "201801",
+    "name": "000000",
+    "periodEndDateTime": "2017-09-15T22:59:59.000+0000",
+    "periodStartDateTime": "2017-09-14T23:00:00.000+0000",
+    "scheduledEndDateTime": "2018-06-29T23:00:00.000+0000",
+    "scheduledExecutionDateTime": "2017-09-10T23:00:00.000+0000",
+    "scheduledReturnDateTime": "2017-10-06T00:00:00.000+0000",
+    "scheduledStartDateTime": "2017-09-11T23:00:00.000+0000",
+    "state": "PUBLISHED",
+    "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+  },
+  {
+    "id": "14fb3e68-4dca-46db-bf49-04b84e07e77d",
+    "actualExecutionDateTime": "2017-11-10T12:14:41.768+0000",
+    "actualPublishDateTime": "2017-11-10T12:16:28.509+0000",
+    "caseTypes": [
+      {
+        "actionPlanId": "e71002ac-3575-47eb-b87f-cd9db92bf9a7",
+        "sampleUnitType": "B"
+      },
+      {
+        "actionPlanId": "0009e978-0932-463b-a2a1-b45cb3ffcb2b",
+        "sampleUnitType": "BI"
+      }
+    ],
+    "executedBy": null,
+    "exerciseRef": "201812",
+    "name": "000000",
+    "periodEndDateTime": "2017-09-15T22:59:59.000+0000",
+    "periodStartDateTime": "2017-09-14T23:00:00.000+0000",
+    "scheduledEndDateTime": "2018-06-29T23:00:00.000+0000",
+    "scheduledExecutionDateTime": "2017-09-10T23:00:00.000+0000",
+    "scheduledReturnDateTime": "2017-10-06T00:00:00.000+0000",
+    "scheduledStartDateTime": "2017-09-11T23:00:00.000+0000",
+    "state": "PUBLISHED",
+    "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+  }
+]


### PR DESCRIPTION
Fixed defect where collection exercises would not show for a given reporting unit when no respondents had enrolled for it

We now also gather collection exercises for a reporting unit from a new endpoint in [this PR](https://github.com/ONSdigital/rm-collection-exercise-service/pull/33)

[Trello](https://trello.com/c/wQF6d3T7/85-us045-int-view-surveys-their-ces-for-an-ru-large)
[Confluence](https://digitaleq.atlassian.net/wiki/spaces/RASB/pages/248414377/US045+INT+View+Surveys+CEs+for+a+Reporting+Unit+Large)