### PR TITLE
Show enrolment code

### DIFF
--- a/config.py
+++ b/config.py
@@ -90,6 +90,13 @@ class Config(object):
                                              RM_SAMPLE_SERVICE_HOST,
                                              RM_SAMPLE_SERVICE_PORT)
 
+    RM_IAC_SERVICE_HOST = os.getenv('RM_IAC_SERVICE_HOST', 'localhost')
+    RM_IAC_SERVICE_PORT = os.getenv('RM_IAC_SERVICE_PORT', 8121)
+    RM_IAC_SERVICE_PROTOCOL = os.getenv('RM_IAC_SERVICE_PROTOCOL', 'http')
+    RM_IAC_SERVICE = '{}://{}:{}/'.format(RM_IAC_SERVICE_PROTOCOL,
+                                          RM_IAC_SERVICE_HOST,
+                                          RM_IAC_SERVICE_PORT)
+
     UAA_SERVICE_URL = os.getenv('UAA_SERVICE_URL')
     UAA_CLIENT_ID = os.getenv('UAA_CLIENT_ID')
     UAA_CLIENT_SECRET = os.getenv('UAA_CLIENT_SECRET')

--- a/ras_backstage/controllers/iac_controller.py
+++ b/ras_backstage/controllers/iac_controller.py
@@ -1,0 +1,23 @@
+import logging
+
+from structlog import wrap_logger
+
+from ras_backstage import app
+from ras_backstage.common.requests_handler import request_handler
+from ras_backstage.exception.exceptions import ApiError
+
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+
+def get_iac(iac_code):
+    logger.debug('Retrieving iac', iac_code=iac_code)
+    url = f'{app.config["RM_IAC_SERVICE"]}iacs/{iac_code}'
+    response = request_handler('GET', url, auth=app.config['BASIC_AUTH'])
+
+    if response.status_code != 200:
+        logger.error('Error retrieving iac', iac_code=iac_code)
+        raise ApiError(url, response.status_code)
+
+    logger.debug('Successfully retrieved iac', iac_code=iac_code)
+    return response.json()

--- a/ras_backstage/controllers/iac_controller.py
+++ b/ras_backstage/controllers/iac_controller.py
@@ -11,13 +11,13 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 
 def get_iac(iac_code):
-    logger.debug('Retrieving iac', iac_code=iac_code)
+    logger.debug('Retrieving iac')
     url = f'{app.config["RM_IAC_SERVICE"]}iacs/{iac_code}'
     response = request_handler('GET', url, auth=app.config['BASIC_AUTH'])
 
     if response.status_code != 200:
-        logger.error('Error retrieving iac', iac_code=iac_code)
+        logger.error('Error retrieving iac')
         raise ApiError(url, response.status_code)
 
-    logger.debug('Successfully retrieved iac', iac_code=iac_code)
+    logger.debug('Successfully retrieved iac')
     return response.json()

--- a/ras_backstage/resources/reporting_units/get_reporting_unit.py
+++ b/ras_backstage/resources/reporting_units/get_reporting_unit.py
@@ -9,8 +9,7 @@ from structlog import wrap_logger
 from ras_backstage import reporting_unit_api
 from ras_backstage.common.filters import get_case_group_status_by_collection_exercise
 from ras_backstage.controllers import (case_controller, collection_exercise_controller, party_controller,
-                                       survey_controller)
-from ras_backstage.controllers import iac_controller
+                                       survey_controller, iac_controller)
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -51,7 +50,7 @@ class GetReportingUnit(Resource):
                                               for collection_exercise in collection_exercises
                                               if survey['id'] == collection_exercise['surveyId']]
             link_respondents_to_survey(respondents, survey)
-            survey['activeIacCode'] = get_latest_activeiac_code(survey['id'], cases, collection_exercises)
+            survey['activeIacCode'] = get_latest_active_iac_code(survey['id'], cases, collection_exercises)
 
         response_json = {
             "reporting_unit": reporting_unit,
@@ -79,7 +78,7 @@ def link_respondents_to_survey(respondents, survey):
                     survey['respondents'].append(respondent)
 
 
-def get_latest_activeiac_code(survey_id, cases, ces_for_survey):
+def get_latest_active_iac_code(survey_id, cases, ces_for_survey):
     cases_for_survey = []
 
     ces_ids = [ce['id'] for ce in ces_for_survey if survey_id == ce['surveyId']]

--- a/test/resources/test_reporting_units.py
+++ b/test/resources/test_reporting_units.py
@@ -32,6 +32,9 @@ url_get_collection_exercise_by_survey = f'{app.config["RM_COLLECTION_EXERCISE_SE
                                         f'collectionexercises/survey/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
 with open('test/test_data/collection_exercise/collection_exercise.json') as json_data:
     collection_exercise = json.load(json_data)
+url_get_iac_by_code = f'{app.config["RM_IAC_SERVICE"]}iacs/jkbvyklkwj88'
+with open('test/test_data/iac_details.json') as json_data:
+    iac_details = json.load(json_data)
 
 
 class TestReportingUnits(unittest.TestCase):
@@ -68,6 +71,7 @@ class TestReportingUnits(unittest.TestCase):
         mock_request.get(url_get_party_by_business_id, json=party_business)
         mock_request.get(url_get_survey_by_id, json=survey_list[0])
         mock_request.get(url_get_party_by_respondent_id, json=party_respondent)
+        mock_request.get(url_get_iac_by_code, json=iac_details)
 
         response = self.app.get("/backstage-api/v1/reporting-unit/12345")
         response_data = json.loads(response.data)

--- a/test/resources/test_reporting_units.py
+++ b/test/resources/test_reporting_units.py
@@ -185,3 +185,19 @@ class TestReportingUnits(unittest.TestCase):
 
         self.assertEqual(response.status_code, 500)
         self.assertEqual(response_data['error']['status_code'], 500)
+
+    @requests_mock.mock()
+    def test_get_reporting_unit_iac_fail(self, mock_request):
+        mock_request.get(url_get_party_by_ru_ref, json=party_business)
+        mock_request.get(url_get_collection_exercises_by_party, json=collection_exercise_list)
+        mock_request.get(url_get_cases_by_business_id, json=case_list)
+        mock_request.get(url_get_party_by_business_id, json=party_business)
+        mock_request.get(url_get_survey_by_id, json=survey_list[0])
+        mock_request.get(url_get_party_by_respondent_id, json=party_respondent)
+        mock_request.get(url_get_iac_by_code, status_code=500)
+
+        response = self.app.get("/backstage-api/v1/reporting-unit/12345")
+        response_data = json.loads(response.data)
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response_data['error']['status_code'], 500)

--- a/test/test_data/iac_details.json
+++ b/test/test_data/iac_details.json
@@ -1,0 +1,7 @@
+{
+  "iac": "jkbvyklkwj88",
+  "active": true,
+  "lastUsedDateTime": "2017-05-15T10:00:00Z",
+  "caseId": "7bc5d41b-0549-40b3-ba76-42f6d4cf3fdb",
+  "questionSet": "H1"
+}


### PR DESCRIPTION
GIVEN
The user understands which surveys the RU Ref has been selected for
WHEN
The surveys are displayed back to the user
THEN
For each survey, the user is displayed the most recent Enrolment Code issued for that RU for that Survey
Enrollment Code displayed is based on the issued code at notification which hasn't yet been used
Once code is used and respondent is fully active and enabled suppress the code
Enrollment Code displayed is last code unused using 'Generate Code'