### PR TITLE
Us029 add collection instrument link endpoint

### DIFF
--- a/ras_backstage/__init__.py
+++ b/ras_backstage/__init__.py
@@ -47,6 +47,7 @@ api.add_namespace(survey_api)
 import ras_backstage.error_handlers  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.collection_exercise.single_collection_exercise import GetSingleCollectionExercise  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.collection_instrument.collection_instrument import CollectionInstrument  # NOQA # pylint: disable=wrong-import-position
+from ras_backstage.resources.collection_instrument.link_exercise import LinkExercise  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.info import Info  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.party.get_party_details import PartyDetails  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.reporting_units.get_reporting_unit import GetReportingUnit  # NOQA # pylint: disable=wrong-import-position

--- a/ras_backstage/controllers/collection_instrument_controller.py
+++ b/ras_backstage/controllers/collection_instrument_controller.py
@@ -27,21 +27,20 @@ def upload_collection_instrument(collection_exercise_id, file):
 
 
 def link_collection_instrument_to_exercise(collection_instrument_id, collection_exercise_id):
-    logger.debug('Uploading collection instrument', collection_instrument_id=collection_instrument_id,
-                 collection_exercise_id=collection_exercise_id)
+    logger.debug('Linking collection instrument to exercise',
+                 collection_instrument_id=collection_instrument_id, collection_exercise_id=collection_exercise_id)
     url = f'{app.config["RAS_COLLECTION_INSTRUMENT_SERVICE"]}' \
           f'collection-instrument-api/1.0.2/link-exercise/{collection_instrument_id}/{collection_exercise_id}'
 
     response = request_handler(url=url, method='POST', auth=app.config['BASIC_AUTH'])
 
     if response.status_code != 200:
-        logger.error('Error uploading collection instrument', collection_instrument_id=collection_instrument_id,
-                     collection_exercise_id=collection_exercise_id)
+        logger.error('Failed to link collection instrument to exercise',
+                     collection_instrument_id=collection_instrument_id, collection_exercise_id=collection_exercise_id)
         raise ApiError(url, response.status_code)
 
-    logger.debug('Successfully uploaded collection instrument',
-                 collection_instrument_id=collection_instrument_id,
-                 collection_exercise_id=collection_exercise_id)
+    logger.debug('Successfully linked collection instrument to exercise',
+                 collection_instrument_id=collection_instrument_id, collection_exercise_id=collection_exercise_id)
 
 
 def get_collection_instruments_by_classifier(survey_id, collection_exercise_id):

--- a/ras_backstage/controllers/collection_instrument_controller.py
+++ b/ras_backstage/controllers/collection_instrument_controller.py
@@ -26,6 +26,24 @@ def upload_collection_instrument(collection_exercise_id, file):
                  collection_exercise_id=collection_exercise_id)
 
 
+def link_collection_instrument_to_exercise(collection_instrument_id, collection_exercise_id):
+    logger.debug('Uploading collection instrument', collection_instrument_id=collection_instrument_id,
+                 collection_exercise_id=collection_exercise_id)
+    url = f'{app.config["RAS_COLLECTION_INSTRUMENT_SERVICE"]}' \
+          f'collection-instrument-api/1.0.2/link-exercise/{collection_instrument_id}/{collection_exercise_id}'
+
+    response = request_handler(url=url, method='POST', auth=app.config['BASIC_AUTH'])
+
+    if response.status_code != 200:
+        logger.error('Error uploading collection instrument', collection_instrument_id=collection_instrument_id,
+                     collection_exercise_id=collection_exercise_id)
+        raise ApiError(url, response.status_code)
+
+    logger.debug('Successfully uploaded collection instrument',
+                 collection_instrument_id=collection_instrument_id,
+                 collection_exercise_id=collection_exercise_id)
+
+
 def get_collection_instruments_by_classifier(survey_id, collection_exercise_id):
     logger.debug('Retrieving collection instruments', survey_id=survey_id,
                  collection_exercise_id=collection_exercise_id)

--- a/ras_backstage/resources/collection_instrument/link_exercise.py
+++ b/ras_backstage/resources/collection_instrument/link_exercise.py
@@ -1,0 +1,25 @@
+import logging
+
+from flask import Response
+from flask_restplus import Resource
+from structlog import wrap_logger
+
+from ras_backstage import collection_instrument_api
+
+from ras_backstage.controllers.collection_instrument_controller import link_collection_instrument_to_exercise
+
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+
+@collection_instrument_api.route('/link/<collection_instrument_id>/<collection_exercise_id>')
+class LinkExercise(Resource):
+
+    @staticmethod
+    def post(collection_instrument_id, collection_exercise_id):
+        logger.info('Linking collection instrument to exercise',
+                    collection_instrument_id=collection_instrument_id, collection_exercise_id=collection_exercise_id)
+        link_collection_instrument_to_exercise(collection_instrument_id, collection_exercise_id)
+        logger.info('Successfully linked collection instrument to exercise',
+                    collection_instrument_id=collection_instrument_id, collection_exercise_id=collection_exercise_id)
+        return Response(status=200)

--- a/ras_backstage/resources/collection_instrument/link_exercise.py
+++ b/ras_backstage/resources/collection_instrument/link_exercise.py
@@ -5,7 +5,6 @@ from flask_restplus import Resource
 from structlog import wrap_logger
 
 from ras_backstage import collection_instrument_api
-
 from ras_backstage.controllers.collection_instrument_controller import link_collection_instrument_to_exercise
 
 

--- a/test/resources/test_collection_instrument.py
+++ b/test/resources/test_collection_instrument.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from io import BytesIO
 
@@ -11,6 +12,8 @@ url_ces = f'{app.config["RM_COLLECTION_EXERCISE_SERVICE"]}' \
     'collectionexercises/survey/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
 url_upload_collection_instrument = f'{app.config["RAS_COLLECTION_INSTRUMENT_SERVICE"]}' \
     f'collection-instrument-api/1.0.2/upload/e33daf0e-6a27-40cd-98dc-c6231f50e84a'
+url_link_collection_instrument = f'{app.config["RAS_COLLECTION_INSTRUMENT_SERVICE"]}collection-instrument-api/1.0.2/' \
+    f'link-exercise/14fb3e68-4dca-46db-bf49-04b84e07e77c/14fb3e68-4dca-46db-bf49-04b84e07e77c'
 
 
 class TestCollectionExercise(unittest.TestCase):
@@ -84,6 +87,24 @@ class TestCollectionExercise(unittest.TestCase):
         response = self.app.post('/backstage-api/v1/collection-instrument/test/000001')
 
         self.assertEqual(response.status_code, 404)
+
+    @requests_mock.mock()
+    def test_link_collection_instrument(self, mock_request):
+        mock_request.post(url_link_collection_instrument)
+
+        response = self.app.post('/backstage-api/v1/collection-instrument/test/000001')
+
+        self.assertEqual(response.status_code, 200)
+
+    @requests_mock.mock()
+    def test_link_collection_instrument_fail(self, mock_request):
+        mock_request.post(url_link_collection_instrument, statu_code=500)
+
+        response = self.app.post('/backstage-api/v1/collection-instrument/test/000001')
+        response_data = json.loads(response.data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_data['surveys'][0]['surveyRef'], "221")
 
     @staticmethod
     def file_matcher(request):

--- a/test/resources/test_collection_instrument.py
+++ b/test/resources/test_collection_instrument.py
@@ -99,7 +99,7 @@ class TestCollectionExercise(unittest.TestCase):
 
     @requests_mock.mock()
     def test_link_collection_instrument_fail(self, mock_request):
-        mock_request.post(url_link_collection_instrument, statu_code=500)
+        mock_request.post(url_link_collection_instrument, status_code=500)
         url = '/backstage-api/v1/collection-instrument/link/' \
               '14fb3e68-4dca-46db-bf49-04b84e07e77c/14fb3e68-4dca-46db-bf49-04b84e07e77c'
 

--- a/test/resources/test_collection_instrument.py
+++ b/test/resources/test_collection_instrument.py
@@ -1,4 +1,3 @@
-import json
 import unittest
 from io import BytesIO
 
@@ -104,10 +103,8 @@ class TestCollectionExercise(unittest.TestCase):
               '14fb3e68-4dca-46db-bf49-04b84e07e77c/14fb3e68-4dca-46db-bf49-04b84e07e77c'
 
         response = self.app.post(url)
-        response_data = json.loads(response.data)
 
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response_data['surveys'][0]['surveyRef'], "221")
+        self.assertEqual(response.status_code, 500)
 
     @staticmethod
     def file_matcher(request):

--- a/test/resources/test_collection_instrument.py
+++ b/test/resources/test_collection_instrument.py
@@ -91,16 +91,19 @@ class TestCollectionExercise(unittest.TestCase):
     @requests_mock.mock()
     def test_link_collection_instrument(self, mock_request):
         mock_request.post(url_link_collection_instrument)
-
-        response = self.app.post('/backstage-api/v1/collection-instrument/test/000001')
+        url = '/backstage-api/v1/collection-instrument/link/' \
+              '14fb3e68-4dca-46db-bf49-04b84e07e77c/14fb3e68-4dca-46db-bf49-04b84e07e77c'
+        response = self.app.post(url)
 
         self.assertEqual(response.status_code, 200)
 
     @requests_mock.mock()
     def test_link_collection_instrument_fail(self, mock_request):
         mock_request.post(url_link_collection_instrument, statu_code=500)
+        url = '/backstage-api/v1/collection-instrument/link/' \
+              '14fb3e68-4dca-46db-bf49-04b84e07e77c/14fb3e68-4dca-46db-bf49-04b84e07e77c'
 
-        response = self.app.post('/backstage-api/v1/collection-instrument/test/000001')
+        response = self.app.post(url)
         response_data = json.loads(response.data)
 
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Added an endpoint which calls the collection instrument service to link a collection instrument to a collection exercise

This is the endpoint that will be called from response-operations-ui when an internal user selects an eQ questionnaire as the collection instrument for a collection exercise

[Trello](https://trello.com/c/QharabAR/42-us029-int-select-load-eq-collection-instruments-xxl)
[Confluence](https://digitaleq.atlassian.net/wiki/spaces/RASB/pages/248643743/US029+Select+EQ+Collection+Instruments+XXL)