### PR TITLE
Add apis to get and change case statuses

### DIFF
--- a/ras_backstage/__init__.py
+++ b/ras_backstage/__init__.py
@@ -26,6 +26,7 @@ collection_instrument_api = Namespace('collection-instrument',
                                       path='/backstage-api/v1/collection-instrument')
 party_api = Namespace('party', path='/backstage-api/v1/party')
 reporting_unit_api = Namespace('reporting-unit', path='/backstage-api/v1/reporting-unit')
+case_api = Namespace('case', path='/backstage-api/v1/case')
 sample_api = Namespace('sample', path='/backstage-api/v1/sample')
 secure_messaging_api = Namespace('secure-messaging',
                                  path='/backstage-api/v1/secure-message')
@@ -33,6 +34,7 @@ sign_in_api = Namespace('sign-in', path='/backstage-api/v1/sign-in')
 sign_in_api_v2 = Namespace('sign-in-v2', path='/backstage-api/v2/sign-in')
 survey_api = Namespace('survey', path='/backstage-api/v1/survey')
 
+api.add_namespace(case_api)
 api.add_namespace(collection_exercise_api)
 api.add_namespace(collection_instrument_api)
 api.add_namespace(party_api)
@@ -51,6 +53,7 @@ from ras_backstage.resources.collection_instrument.link_exercise import LinkExer
 from ras_backstage.resources.info import Info  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.party.get_party_details import PartyDetails  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.reporting_units.get_reporting_unit import GetReportingUnit  # NOQA # pylint: disable=wrong-import-position
+from ras_backstage.resources.case.reporting_unit_case_group_status import ReportingUnitCaseGroupStatus  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.reporting_units.search_reporting_units import SearchReportingUnits  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.sample.sample import Sample  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.secure_messaging.get_message_list import GetMessagesList  # NOQA # pylint: disable=wrong-import-position

--- a/ras_backstage/controllers/case_controller.py
+++ b/ras_backstage/controllers/case_controller.py
@@ -24,3 +24,30 @@ def get_cases_by_business_party_id(business_party_id):
 
     logger.debug('Successfully retrieved cases', business_party_id=business_party_id)
     return response.json()
+
+
+def get_available_statuses_for_ru_ref(collection_exercise_id, ru_ref):
+    logger.debug('Retrieving statuses', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref)
+    url = f'{app.config["RM_CASE_SERVICE"]}casegroups/transitions/{collection_exercise_id}/{ru_ref}'
+    response = request_handler('GET', url, auth=app.config['BASIC_AUTH'])
+
+    if response.status_code != 200:
+        logger.error('Error retrieving statuses', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref)
+        raise ApiError(url, response.status_code)
+
+    logger.debug('Successfully retrieved statuses', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref)
+    return response.json()
+
+
+def update_case_group_status(collection_exercise_id, ru_ref, case_group_event):
+    logger.debug('Updating status', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref, case_group_event=case_group_event)
+    url = f'{app.config["RM_CASE_SERVICE"]}casegroups/transitions/{collection_exercise_id}/{ru_ref}'
+    response = request_handler('PUT', url, auth=app.config['BASIC_AUTH'], json={'event': case_group_event})
+
+    if response.status_code != 200:
+        logger.error('Error updating status', collection_exercise_id=collection_exercise_id,ru_ref=ru_ref,
+                     case_group_event=case_group_event)
+        raise ApiError(url, response.status_code)
+
+    logger.debug('Successfully updated status', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref,
+                 case_group_event=case_group_event)

--- a/ras_backstage/resources/case/reporting_unit_case_group_status.py
+++ b/ras_backstage/resources/case/reporting_unit_case_group_status.py
@@ -1,0 +1,90 @@
+import logging
+
+from flask import jsonify, make_response, Response, request
+from flask_restplus import Resource, reqparse, fields
+from structlog import wrap_logger
+
+from ras_backstage import case_api
+from ras_backstage.common.filters import get_collection_exercise_by_period, get_case_group_status_by_collection_exercise
+from ras_backstage.common.mappers import format_short_name
+from ras_backstage.controllers import survey_controller, collection_exercise_controller, party_controller, \
+    case_controller
+from ras_backstage.controllers.case_controller import get_available_statuses_for_ru_ref
+
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+
+def filter_statuses(current_status, statuses):
+    manual_transisitions = {
+        'NOTSTARTED': ['COMPLETEDBYPHONE'],
+        'INPROGRESS': ['COMPLETEDBYPHONE'],
+        'REOPENED': ['COMPLETEDBYPHONE']
+    }
+    allowed_transitions = manual_transisitions.get(current_status)
+    return {event: status for event, status in statuses.items() if status in allowed_transitions}
+
+
+validate_enrolment_details = case_api.model('ValidateReportingUnitCaseGroupStatus', {
+    'event': fields.String(required=True),
+})
+
+
+@case_api.route('/status/<short_name>/<period>/<ru_ref>')
+class ReportingUnitCaseGroupStatus(Resource):
+
+    @staticmethod
+    def get(short_name, period, ru_ref):
+        logger.info('Retrieving available statuses for reporting unit', short_name=short_name, period=period,
+                    ru_ref=ru_ref)
+
+        survey = survey_controller.get_survey_by_shortname(short_name)
+        survey['shortName'] = format_short_name(survey['shortName'])
+
+        # Get all collection exercises for ru_ref
+        exercises = collection_exercise_controller.get_collection_exercises_by_survey(survey['id'])
+
+        # Find the collection exercise for the given period
+        exercise = get_collection_exercise_by_period(exercises, period)
+
+        reporting_unit_details = party_controller.get_party_by_ru_ref(ru_ref)
+
+        cases = case_controller.get_cases_by_business_party_id(reporting_unit_details['id'])
+
+        current_status = get_case_group_status_by_collection_exercise(cases, exercise['id'])
+
+        statuses = get_available_statuses_for_ru_ref(exercise['id'], ru_ref)
+
+        statuses = filter_statuses(current_status, statuses)
+
+        response = {
+            'ru_ref': ru_ref,
+            'trading_as': reporting_unit_details['name'],
+            'survey_id': survey['surveyRef'],
+            'short_name': short_name,
+            'current_status': current_status,
+            'available_statuses': statuses
+        }
+
+        logger.info('Successfully retrieved available statuses for reporting unit',
+                    short_name=short_name, period=period, ru_ref=ru_ref)
+        return make_response(jsonify(response), 200)
+
+    @staticmethod
+    @case_api.expect(validate_enrolment_details, validate=True)
+    def post(short_name, period, ru_ref):
+        logger.info('Updating available status', short_name=short_name, period=period,
+                    ru_ref=ru_ref)
+        body = request.json
+
+        survey = survey_controller.get_survey_by_shortname(short_name)
+        survey['shortName'] = format_short_name(survey['shortName'])
+
+        # Get all collection exercises for ru_ref
+        exercises = collection_exercise_controller.get_collection_exercises_by_survey(survey['id'])
+
+        # Find the collection exercise for the given period
+        exercise = get_collection_exercise_by_period(exercises, period)
+        case_controller.update_case_group_status(exercise['id'], ru_ref, body['event'])
+
+        return Response(status=200)

--- a/ras_backstage/resources/case/reporting_unit_case_group_status.py
+++ b/ras_backstage/resources/case/reporting_unit_case_group_status.py
@@ -1,7 +1,7 @@
 import logging
 
 from flask import jsonify, make_response, Response, request
-from flask_restplus import Resource, reqparse, fields
+from flask_restplus import Resource, fields
 from structlog import wrap_logger
 
 from ras_backstage import case_api
@@ -10,7 +10,6 @@ from ras_backstage.common.mappers import format_short_name
 from ras_backstage.controllers import survey_controller, collection_exercise_controller, party_controller, \
     case_controller
 from ras_backstage.controllers.case_controller import get_available_statuses_for_ru_ref
-
 
 logger = wrap_logger(logging.getLogger(__name__))
 

--- a/test/resources/test_reporting_unit_case_group_status.py
+++ b/test/resources/test_reporting_unit_case_group_status.py
@@ -172,7 +172,7 @@ class TestReportingUnits(unittest.TestCase):
 
         # When
         response = self.app.post("/backstage-api/v1/case/status/BRES/201801/12345",
-                                 data=json.dumps({}), content_type='application/json')
+                                 data=json.dumps(body), content_type='application/json')
 
         # Then
         self.assertEqual(response.status_code, 400)

--- a/test/resources/test_reporting_unit_case_group_status.py
+++ b/test/resources/test_reporting_unit_case_group_status.py
@@ -4,7 +4,7 @@ import unittest
 import requests_mock
 
 from ras_backstage import app
-from ras_backstage.resources.case.reporting_unit_case_group_status import filter_statuses
+from ras_backstage.controllers.case_controller import filter_statuses
 
 url_get_party_by_ru_ref = f'{app.config["RAS_PARTY_SERVICE"]}party-api/v1/parties/type/B/ref/12345'
 with open('test/test_data/party/business_party.json') as json_data:
@@ -65,60 +65,6 @@ class TestReportingUnits(unittest.TestCase):
         self.assertEqual(response_data['available_statuses']['COMPLETEDBYPHONE'], "COMPLETEDBYPHONE")
 
     @requests_mock.mock()
-    def test_filter_other_options_when_not_started(self, mock_request):
-        # Given
-        current_status = 'INPROGRESS'
-        statuses = {
-            'UPLOAD': 'COMPLETED',
-            'COMPLETEDBYPHONE': 'COMPLETEDBYPHONE',
-            'SOMETHING': 'SOMETHING',
-        }
-
-        # When
-        filtered_statuses = filter_statuses(current_status, statuses)
-
-        # Then
-        self.assertEqual(filtered_statuses['COMPLETEDBYPHONE'], 'COMPLETEDBYPHONE')
-        self.assertNotIn('COMPLETED', filtered_statuses.values())
-        self.assertNotIn('SOMETHING', filtered_statuses.values())
-
-    @requests_mock.mock()
-    def test_filter_other_options_when_in_progress(self, mock_request):
-        # Given
-        current_status = 'INPROGRESS'
-        statuses = {
-            'UPLOAD': 'COMPLETED',
-            'COMPLETEDBYPHONE': 'COMPLETEDBYPHONE',
-            'SOMETHING': 'SOMETHING',
-        }
-
-        # When
-        filtered_statuses = filter_statuses(current_status, statuses)
-
-        # Then
-        self.assertEqual(filtered_statuses['COMPLETEDBYPHONE'], 'COMPLETEDBYPHONE')
-        self.assertNotIn('COMPLETED', filtered_statuses.values())
-        self.assertNotIn('SOMETHING', filtered_statuses.values())
-
-    @requests_mock.mock()
-    def test_filter_other_options_when_reopened(self, mock_request):
-        # Given
-        current_status = 'REOPENED'
-        statuses = {
-            'UPLOAD': 'COMPLETED',
-            'COMPLETEDBYPHONE': 'COMPLETEDBYPHONE',
-            'SOMETHING': 'SOMETHING',
-        }
-
-        # When
-        filtered_statuses = filter_statuses(current_status, statuses)
-
-        # Then
-        self.assertEqual(filtered_statuses['COMPLETEDBYPHONE'], 'COMPLETEDBYPHONE')
-        self.assertNotIn('COMPLETED', filtered_statuses.values())
-        self.assertNotIn('SOMETHING', filtered_statuses.values())
-
-    @requests_mock.mock()
     def test_get_reporting_unit_statuses_fail(self, mock_request):
         # Given
         mock_request.get(url_get_party_by_ru_ref, json=party_business)
@@ -176,3 +122,58 @@ class TestReportingUnits(unittest.TestCase):
 
         # Then
         self.assertEqual(response.status_code, 400)
+
+
+    @requests_mock.mock()
+    def test_filter_other_options_when_not_started(self, mock_request):
+        # Given
+        current_status = 'INPROGRESS'
+        statuses = {
+            'UPLOAD': 'COMPLETED',
+            'COMPLETEDBYPHONE': 'COMPLETEDBYPHONE',
+            'SOMETHING': 'SOMETHING',
+        }
+
+        # When
+        filtered_statuses = filter_statuses(current_status, statuses)
+
+        # Then
+        self.assertEqual(filtered_statuses['COMPLETEDBYPHONE'], 'COMPLETEDBYPHONE')
+        self.assertNotIn('COMPLETED', filtered_statuses.values())
+        self.assertNotIn('SOMETHING', filtered_statuses.values())
+
+    @requests_mock.mock()
+    def test_filter_other_options_when_in_progress(self, mock_request):
+        # Given
+        current_status = 'INPROGRESS'
+        statuses = {
+            'UPLOAD': 'COMPLETED',
+            'COMPLETEDBYPHONE': 'COMPLETEDBYPHONE',
+            'SOMETHING': 'SOMETHING',
+        }
+
+        # When
+        filtered_statuses = filter_statuses(current_status, statuses)
+
+        # Then
+        self.assertEqual(filtered_statuses['COMPLETEDBYPHONE'], 'COMPLETEDBYPHONE')
+        self.assertNotIn('COMPLETED', filtered_statuses.values())
+        self.assertNotIn('SOMETHING', filtered_statuses.values())
+
+    @requests_mock.mock()
+    def test_filter_other_options_when_reopened(self, mock_request):
+        # Given
+        current_status = 'REOPENED'
+        statuses = {
+            'UPLOAD': 'COMPLETED',
+            'COMPLETEDBYPHONE': 'COMPLETEDBYPHONE',
+            'SOMETHING': 'SOMETHING',
+        }
+
+        # When
+        filtered_statuses = filter_statuses(current_status, statuses)
+
+        # Then
+        self.assertEqual(filtered_statuses['COMPLETEDBYPHONE'], 'COMPLETEDBYPHONE')
+        self.assertNotIn('COMPLETED', filtered_statuses.values())
+        self.assertNotIn('SOMETHING', filtered_statuses.values())

--- a/test/resources/test_reporting_unit_case_group_status.py
+++ b/test/resources/test_reporting_unit_case_group_status.py
@@ -1,0 +1,178 @@
+import json
+import unittest
+
+import requests_mock
+
+from ras_backstage import app
+from ras_backstage.resources.case.reporting_unit_case_group_status import filter_statuses
+
+url_get_party_by_ru_ref = f'{app.config["RAS_PARTY_SERVICE"]}party-api/v1/parties/type/B/ref/12345'
+with open('test/test_data/party/business_party.json') as json_data:
+    party_business = json.load(json_data)
+
+url_get_cases_by_business_id = f'{app.config["RM_CASE_SERVICE"]}cases/partyid/b3ba864b-7cbc-4f44-84fe-88dc018a1a4c'
+with open('test/test_data/case/case_list.json') as json_data:
+    case_list = json.load(json_data)
+
+url_get_statuses_for_ru_ref = f'{app.config["RM_CASE_SERVICE"]}' \
+                              f'casegroups/transitions/14fb3e68-4dca-46db-bf49-04b84e07e77c/12345'
+url_update_status_for_ru_ref = f'{app.config["RM_CASE_SERVICE"]}' \
+                              f'casegroups/transitions/14fb3e68-4dca-46db-bf49-04b84e07e77c/12345'
+
+url_get_survey_by_short_name = f'{app.config["RM_SURVEY_SERVICE"]}surveys/shortname/BRES'
+
+url_get_collection_exercises_by_survey = f'{app.config["RM_COLLECTION_EXERCISE_SERVICE"]}' \
+                                        f'collectionexercises/survey/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
+with open('test/test_data/collection_exercise/collection_exercise_list.json') as json_data:
+    collection_exercises = json.load(json_data)
+
+
+class TestReportingUnits(unittest.TestCase):
+
+    def setUp(self):
+        self.app = app.test_client()
+        self.survey = {
+            "id": 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
+            "longName": "Business Register and Employment Survey",
+            "shortName": "BRES",
+            "surveyRef": "221"
+        }
+        self.statuses = {
+            "UPLOADED": "COMPLETE",
+            "COMPLETEDBYPHONE": "COMPLETEDBYPHONE"
+        }
+
+    @requests_mock.mock()
+    def test_get_reporting_unit_statuses(self, mock_request):
+        # Given
+        mock_request.get(url_get_party_by_ru_ref, json=party_business)
+        mock_request.get(url_get_cases_by_business_id, json=case_list)
+        mock_request.get(url_get_survey_by_short_name, json=self.survey)
+        mock_request.get(url_get_collection_exercises_by_survey, json=collection_exercises)
+        self.statuses = {
+            "UPLOADED": "COMPLETE",
+            "COMPLETEDBYPHONE": "COMPLETEDBYPHONE"
+        }
+        mock_request.get(url_get_statuses_for_ru_ref, json=self.statuses)
+
+        # When
+        response = self.app.get("/backstage-api/v1/case/status/BRES/201801/12345")
+        response_data = json.loads(response.data)
+
+        # Then
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_data['current_status'], 'NOTSTARTED')
+        self.assertEqual(response_data['available_statuses']['COMPLETEDBYPHONE'], "COMPLETEDBYPHONE")
+
+    @requests_mock.mock()
+    def test_filter_other_options_when_not_started(self, mock_request):
+        # Given
+        current_status = 'INPROGRESS'
+        statuses = {
+            'UPLOAD': 'COMPLETED',
+            'COMPLETEDBYPHONE': 'COMPLETEDBYPHONE',
+            'SOMETHING': 'SOMETHING',
+        }
+
+        # When
+        filtered_statuses = filter_statuses(current_status, statuses)
+
+        # Then
+        self.assertEqual(filtered_statuses['COMPLETEDBYPHONE'], 'COMPLETEDBYPHONE')
+        self.assertNotIn('COMPLETED', filtered_statuses.values())
+        self.assertNotIn('SOMETHING', filtered_statuses.values())
+
+    @requests_mock.mock()
+    def test_filter_other_options_when_in_progress(self, mock_request):
+        # Given
+        current_status = 'INPROGRESS'
+        statuses = {
+            'UPLOAD': 'COMPLETED',
+            'COMPLETEDBYPHONE': 'COMPLETEDBYPHONE',
+            'SOMETHING': 'SOMETHING',
+        }
+
+        # When
+        filtered_statuses = filter_statuses(current_status, statuses)
+
+        # Then
+        self.assertEqual(filtered_statuses['COMPLETEDBYPHONE'], 'COMPLETEDBYPHONE')
+        self.assertNotIn('COMPLETED', filtered_statuses.values())
+        self.assertNotIn('SOMETHING', filtered_statuses.values())
+
+    @requests_mock.mock()
+    def test_filter_other_options_when_reopened(self, mock_request):
+        # Given
+        current_status = 'REOPENED'
+        statuses = {
+            'UPLOAD': 'COMPLETED',
+            'COMPLETEDBYPHONE': 'COMPLETEDBYPHONE',
+            'SOMETHING': 'SOMETHING',
+        }
+
+        # When
+        filtered_statuses = filter_statuses(current_status, statuses)
+
+        # Then
+        self.assertEqual(filtered_statuses['COMPLETEDBYPHONE'], 'COMPLETEDBYPHONE')
+        self.assertNotIn('COMPLETED', filtered_statuses.values())
+        self.assertNotIn('SOMETHING', filtered_statuses.values())
+
+    @requests_mock.mock()
+    def test_get_reporting_unit_statuses_fail(self, mock_request):
+        # Given
+        mock_request.get(url_get_party_by_ru_ref, json=party_business)
+        mock_request.get(url_get_cases_by_business_id, json=case_list)
+        mock_request.get(url_get_survey_by_short_name, json=self.survey)
+        mock_request.get(url_get_collection_exercises_by_survey, json=collection_exercises)
+        mock_request.get(url_get_statuses_for_ru_ref, status_code=500)
+
+        response = self.app.get("/backstage-api/v1/case/status/BRES/201801/12345")
+        response_data = json.loads(response.data)
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response_data['error']['status_code'], 500)
+
+    @requests_mock.mock()
+    def test_should_update_status_to_completed_by_phone(self, mock_request):
+        # Given
+        mock_request.get(url_get_party_by_ru_ref, json=party_business)
+        mock_request.get(url_get_cases_by_business_id, json=case_list)
+        mock_request.get(url_get_survey_by_short_name, json=self.survey)
+        mock_request.get(url_get_collection_exercises_by_survey, json=collection_exercises)
+        mock_request.put(url_update_status_for_ru_ref,
+                         additional_matcher=lambda r: {'event': 'COMPLETEDBYPHONE'} == r.json())
+
+        # When
+        response = self.app.post("/backstage-api/v1/case/status/BRES/201801/12345",
+                                 data=json.dumps({'event': 'COMPLETEDBYPHONE'}), content_type='application/json')
+
+        # Then
+        self.assertEqual(response.status_code, 200)
+
+    @requests_mock.mock()
+    def test_should_return_api_error_code_when_update_status_fails(self, mock_request):
+        # Given
+        mock_request.get(url_get_party_by_ru_ref, json=party_business)
+        mock_request.get(url_get_cases_by_business_id, json=case_list)
+        mock_request.get(url_get_survey_by_short_name, json=self.survey)
+        mock_request.get(url_get_collection_exercises_by_survey, json=collection_exercises)
+        mock_request.put(url_update_status_for_ru_ref, status_code=503)
+
+        # When
+        response = self.app.post("/backstage-api/v1/case/status/BRES/201801/12345",
+                                 data=json.dumps({'event': 'COMPLETEDBYPHONE'}), content_type='application/json')
+
+        # Then
+        self.assertEqual(response.status_code, 503)
+
+    def test_should_return_400_when_event_not_posted(self):
+        # Given
+        body = {}
+
+        # When
+        response = self.app.post("/backstage-api/v1/case/status/BRES/201801/12345",
+                                 data=json.dumps({}), content_type='application/json')
+
+        # Then
+        self.assertEqual(response.status_code, 400)

--- a/test/test_data/case/case_group_statuses.json
+++ b/test/test_data/case/case_group_statuses.json
@@ -1,0 +1,11 @@
+{
+  "ru_ref": "12345",
+  "trading_as": "Bolts and Ratchets Ltd",
+  "survey_id": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
+  "short_name": "BRES",
+  "current_status": "NOTSTARTED",
+  "available_statuses": [
+    "COMPLETE",
+    "COMPLETEDBYPHONE"
+  ]
+}


### PR DESCRIPTION
As a internal user (Survey administrator?)
I need to change the case response status to completed by phone for an
RU for a specific CE for a specific survey
So that the respondent can complete the survey over the phone and they
do not receive reminders

* Add an API to get available state transitions and events to cause
  those transitions from case-service
* Add an API to fire event to cause transition
* Limit the transitions a user can do

### Testing
1. Run up ras/rm
1. Run response-operations-ui on branch `us050-manually-change-the-response-status`
1. Run ras-backstage on branch `us050a-change-response-status`
1. Build repo `rm-common-service` branch `us050a-change-response-status-completedbyphone`
1. Build rm-casesvc-api on branch `us050a-change-response-status`
1. Run rm-case-service on branch `us050a-change-response-status-completedbyphone`
1. Load data with `make setup`
1. Open http://localhost:8085/reporting-units/49900000001
1. Click change
1. See updated status

[trello](https://trello.com/c/q5skwt1o/91-us050a-int-manually-change-the-response-status-for-a-given-ru-survey-ce-to-completed-by-phone-xl)