### PR TITLE
Us051 generate new enrolment code

### DIFF
--- a/ras_backstage/__init__.py
+++ b/ras_backstage/__init__.py
@@ -59,6 +59,7 @@ from ras_backstage.resources.collection_instrument.link_exercise import LinkExer
 from ras_backstage.resources.info import Info  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.party.get_party_details import PartyDetails  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.reporting_units.get_reporting_unit import GetReportingUnit  # NOQA # pylint: disable=wrong-import-position
+from ras_backstage.resources.reporting_units.generate_new_enrolment_code import GenerateNewEnrolmentCode  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.case.reporting_unit_case_group_status import ReportingUnitCaseGroupStatus  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.reporting_units.search_reporting_units import SearchReportingUnits  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.sample.sample import Sample  # NOQA # pylint: disable=wrong-import-position

--- a/ras_backstage/controllers/case_controller.py
+++ b/ras_backstage/controllers/case_controller.py
@@ -62,3 +62,16 @@ def update_case_group_status(collection_exercise_id, ru_ref, case_group_event):
 
     logger.debug('Successfully updated status', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref,
                  case_group_event=case_group_event)
+
+
+def generate_new_enrolment_code(collection_exercise_id, ru_ref):
+    logger.debug('Generating new enrolment code', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref)
+    url = f'{app.config["RM_CASE_SERVICE"]}cases/iac/{collection_exercise_id}/{ru_ref}'
+    response = request_handler('POST', url, auth=app.config['BASIC_AUTH'])
+
+    if response.status_code != 200:
+        logger.error('Failed to generate new enrolment code', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref)
+        raise ApiError(url, response.status_code)
+
+    logger.debug('Successfully generated new enrolment code', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref)
+    return response.json()

--- a/ras_backstage/resources/reporting_units/generate_new_enrolment_code.py
+++ b/ras_backstage/resources/reporting_units/generate_new_enrolment_code.py
@@ -1,0 +1,20 @@
+import logging
+
+from flask_restplus import Resource
+from structlog import wrap_logger
+
+from ras_backstage import reporting_unit_api
+from ras_backstage.controllers import case_controller
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+
+@reporting_unit_api.route('/iac/<collection_exercise_id>/<ru_ref>')
+class GenerateNewEnrolmentCode(Resource):
+
+    @staticmethod
+    def post(collection_exercise_id, ru_ref):
+        logger.info('Generating new enrolment code', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref)
+        case = case_controller.generate_new_enrolment_code(collection_exercise_id, ru_ref)
+        logger.info('Successfully generated new enrolment code', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref)
+        return case

--- a/test/resources/test_reporting_unit_generate_code.py
+++ b/test/resources/test_reporting_unit_generate_code.py
@@ -1,0 +1,37 @@
+import json
+import unittest
+
+import requests_mock
+
+from ras_backstage import app
+
+
+url_generate_new_code = f'{app.config["RM_CASE_SERVICE"]}cases/iac/ce_id/ru_ref'
+with open('test/test_data/case/case_list.json') as json_data:
+    case = json.load(json_data)[0]
+
+
+class TestReportingUnitsGenerateNewCode(unittest.TestCase):
+
+    def setUp(self):
+        self.app = app.test_client()
+
+    @requests_mock.mock()
+    def test_generate_new_code(self, mock_request):
+        mock_request.post(url_generate_new_code, json=case)
+
+        response = self.app.post("/backstage-api/v1/reporting-unit/iac/ce_id/ru_ref")
+        response_data = json.loads(response.data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_data["iac"], "jkbvyklkwj88")
+
+    @requests_mock.mock()
+    def test_generate_new_code_fail(self, mock_request):
+        mock_request.post(url_generate_new_code, json=case, status_code=500)
+
+        response = self.app.post("/backstage-api/v1/reporting-unit/iac/ce_id/ru_ref")
+        response_data = json.loads(response.data)
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response_data['error']['status_code'], 500)


### PR DESCRIPTION
Added new endpoint which posts to the new endpoint in case service for generating a new enrolment code

To test, run with other PR's
[response-operations-ui](https://github.com/ONSdigital/response-operations-ui/pull/85)
[rm-case-service](https://github.com/ONSdigital/rm-case-service/pull/19)
[rasrm-acceptance-tests](https://github.com/ONSdigital/rasrm-acceptance-tests/pull/68)

[Trello](https://trello.com/c/FIBrMsOb/72-us051-int-generate-a-new-additional-enrolment-code-l-25pts-5d)
[Confluence](https://digitaleq.atlassian.net/wiki/spaces/RASB/pages/227115065/US051+Provide+a+new+Enrollment+Code+to+an+RU+for+a+specific+survey+over+the+phone+Large)