### PR TITLE
catch 404 for statuses

### DIFF
--- a/ras_backstage/controllers/case_controller.py
+++ b/ras_backstage/controllers/case_controller.py
@@ -41,6 +41,10 @@ def get_available_statuses_for_ru_ref(current_status, collection_exercise_id, ru
     url = f'{app.config["RM_CASE_SERVICE"]}casegroups/transitions/{collection_exercise_id}/{ru_ref}'
     response = request_handler('GET', url, auth=app.config['BASIC_AUTH'])
 
+    if response.status_code == 404:
+        logger.debug('No statuses found', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref)
+        return []
+
     if response.status_code != 200:
         logger.error('Error retrieving statuses', collection_exercise_id=collection_exercise_id, ru_ref=ru_ref)
         raise ApiError(url, response.status_code)

--- a/test/resources/test_reporting_unit_case_group_status.py
+++ b/test/resources/test_reporting_unit_case_group_status.py
@@ -80,6 +80,24 @@ class TestReportingUnits(unittest.TestCase):
         self.assertEqual(response_data['error']['status_code'], 500)
 
     @requests_mock.mock()
+    def test_get_reporting_unit_statuses_no_statuses(self, mock_request):
+        # Given
+        mock_request.get(url_get_party_by_ru_ref, json=party_business)
+        mock_request.get(url_get_cases_by_business_id, json=case_list)
+        mock_request.get(url_get_survey_by_short_name, json=self.survey)
+        mock_request.get(url_get_collection_exercises_by_survey, json=collection_exercises)
+        mock_request.get(url_get_statuses_for_ru_ref, status_code=404)
+
+        # When
+        response = self.app.get("/backstage-api/v1/case/status/BRES/201801/12345")
+        response_data = json.loads(response.data)
+
+        # Then
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_data['current_status'], 'NOTSTARTED')
+        self.assertEqual(response_data['available_statuses'], [])
+
+    @requests_mock.mock()
     def test_should_update_status_to_completed_by_phone(self, mock_request):
         # Given
         mock_request.get(url_get_party_by_ru_ref, json=party_business)


### PR DESCRIPTION
Reporting unit page should render even if there are no statuses for a given RU. To fix this i'm catching the 404 sent by the case service instead of returning an api error back to response operations. 

Response operations should run as usual without any changes as https://github.com/ONSdigital/response-operations-ui/blob/739e6ecffbb00bec707d503c7148bacc71131efe/response_operations_ui/views/reporting_units.py#L33
handles empty lists as a response.