### PR TITLE
Fix/get case group status for ce

### DIFF
--- a/ras_backstage/common/filters.py
+++ b/ras_backstage/common/filters.py
@@ -4,7 +4,7 @@ def get_collection_exercise_by_period(exercises, period):
             return exercise
 
 
-def get_case_group_status_by_collection_exercise(cases, collection_exercise_id):
-    for case in cases:
-        if case['caseGroup']['collectionExerciseId'] == collection_exercise_id:
-            return case['caseGroup']['caseGroupStatus']
+def get_case_group_status_by_collection_exercise(case_groups, collection_exercise_id):
+    for case_group in case_groups:
+        if case_group['collectionExerciseId'] == collection_exercise_id:
+            return case_group['caseGroupStatus']

--- a/ras_backstage/controllers/case_controller.py
+++ b/ras_backstage/controllers/case_controller.py
@@ -26,6 +26,22 @@ def get_cases_by_business_party_id(business_party_id):
     return response.json()
 
 
+def get_case_groups_by_business_party_id(business_party_id):
+    logger.debug('Retrieving case groups', business_party_id=business_party_id)
+    url = f'{app.config["RM_CASE_SERVICE"]}casegroups/partyid/{business_party_id}'
+    response = request_handler('GET', url, auth=app.config['BASIC_AUTH'])
+
+    if response.status_code == 204:
+        logger.debug('No caseGroups found for business', business_party_id=business_party_id)
+        return []
+    if response.status_code != 200:
+        logger.error('Error retrieving cases', business_party_id=business_party_id)
+        raise ApiError(url, response.status_code)
+
+    logger.debug('Successfully retrieved caseGroups', business_party_id=business_party_id)
+    return response.json()
+
+
 def filter_statuses(current_status, statuses):
     manual_transisitions = {
         'NOTSTARTED': ['COMPLETEDBYPHONE'],

--- a/ras_backstage/resources/case/reporting_unit_case_group_status.py
+++ b/ras_backstage/resources/case/reporting_unit_case_group_status.py
@@ -38,9 +38,9 @@ class ReportingUnitCaseGroupStatus(Resource):
 
         reporting_unit_details = party_controller.get_party_by_ru_ref(ru_ref)
 
-        cases = case_controller.get_cases_by_business_party_id(reporting_unit_details['id'])
+        case_groups = case_controller.get_case_groups_by_business_party_id(reporting_unit_details['id'])
 
-        current_status = get_case_group_status_by_collection_exercise(cases, exercise['id'])
+        current_status = get_case_group_status_by_collection_exercise(case_groups, exercise['id'])
 
         statuses = get_available_statuses_for_ru_ref(current_status, exercise['id'], ru_ref)
 

--- a/ras_backstage/resources/reporting_units/get_reporting_unit.py
+++ b/ras_backstage/resources/reporting_units/get_reporting_unit.py
@@ -31,8 +31,8 @@ class GetReportingUnit(Resource):
                                 if parse_date(collection_exercise['scheduledStartDateTime']) < now]
 
         # Add extra collection exercise details using data from case service
-        cases = case_controller.get_cases_by_business_party_id(reporting_unit['id'])
-        add_collection_exercise_details(collection_exercises, reporting_unit, cases)
+        case_groups = case_controller.get_case_groups_by_business_party_id(reporting_unit['id'])
+        add_collection_exercise_details(collection_exercises, reporting_unit, case_groups)
 
         # Get all surveys for gathered collection exercises
         survey_ids = {collection_exercise['surveyId']
@@ -45,6 +45,7 @@ class GetReportingUnit(Resource):
                        for respondent in reporting_unit.get('associations')]
 
         # Link collection exercises and respondents to surveys
+        cases = case_controller.get_cases_by_business_party_id(reporting_unit['id'])
         for survey in surveys:
             survey['collection_exercises'] = [collection_exercise
                                               for collection_exercise in collection_exercises
@@ -60,9 +61,9 @@ class GetReportingUnit(Resource):
         return make_response(jsonify(response_json), 200)
 
 
-def add_collection_exercise_details(collection_exercises, reporting_unit, cases):
+def add_collection_exercise_details(collection_exercises, reporting_unit, case_groups):
     for exercise in collection_exercises:
-        exercise['responseStatus'] = get_case_group_status_by_collection_exercise(cases, exercise['id'])
+        exercise['responseStatus'] = get_case_group_status_by_collection_exercise(case_groups, exercise['id'])
         reporting_unit_ce = party_controller.get_party_by_business_id(reporting_unit['id'], exercise['id'])
         exercise['companyName'] = reporting_unit_ce['name']
         exercise['companyRegion'] = reporting_unit_ce['region']

--- a/test/resources/test_reporting_unit_case_group_status.py
+++ b/test/resources/test_reporting_unit_case_group_status.py
@@ -10,9 +10,9 @@ url_get_party_by_ru_ref = f'{app.config["RAS_PARTY_SERVICE"]}party-api/v1/partie
 with open('test/test_data/party/business_party.json') as json_data:
     party_business = json.load(json_data)
 
-url_get_cases_by_business_id = f'{app.config["RM_CASE_SERVICE"]}cases/partyid/b3ba864b-7cbc-4f44-84fe-88dc018a1a4c'
-with open('test/test_data/case/case_list.json') as json_data:
-    case_list = json.load(json_data)
+url_get_case_groups_by_business_id = f'{app.config["RM_CASE_SERVICE"]}casegroups/partyid/b3ba864b-7cbc-4f44-84fe-88dc018a1a4c'
+with open('test/test_data/case/case_groups.json') as json_data:
+    case_group_list = json.load(json_data)
 
 url_get_statuses_for_ru_ref = f'{app.config["RM_CASE_SERVICE"]}' \
                               f'casegroups/transitions/14fb3e68-4dca-46db-bf49-04b84e07e77c/12345'
@@ -46,7 +46,7 @@ class TestReportingUnits(unittest.TestCase):
     def test_get_reporting_unit_statuses(self, mock_request):
         # Given
         mock_request.get(url_get_party_by_ru_ref, json=party_business)
-        mock_request.get(url_get_cases_by_business_id, json=case_list)
+        mock_request.get(url_get_case_groups_by_business_id, json=case_group_list)
         mock_request.get(url_get_survey_by_short_name, json=self.survey)
         mock_request.get(url_get_collection_exercises_by_survey, json=collection_exercises)
         self.statuses = {
@@ -68,7 +68,7 @@ class TestReportingUnits(unittest.TestCase):
     def test_get_reporting_unit_statuses_fail(self, mock_request):
         # Given
         mock_request.get(url_get_party_by_ru_ref, json=party_business)
-        mock_request.get(url_get_cases_by_business_id, json=case_list)
+        mock_request.get(url_get_case_groups_by_business_id, json=case_group_list)
         mock_request.get(url_get_survey_by_short_name, json=self.survey)
         mock_request.get(url_get_collection_exercises_by_survey, json=collection_exercises)
         mock_request.get(url_get_statuses_for_ru_ref, status_code=500)
@@ -83,7 +83,7 @@ class TestReportingUnits(unittest.TestCase):
     def test_get_reporting_unit_statuses_no_statuses(self, mock_request):
         # Given
         mock_request.get(url_get_party_by_ru_ref, json=party_business)
-        mock_request.get(url_get_cases_by_business_id, json=case_list)
+        mock_request.get(url_get_case_groups_by_business_id, json=case_group_list)
         mock_request.get(url_get_survey_by_short_name, json=self.survey)
         mock_request.get(url_get_collection_exercises_by_survey, json=collection_exercises)
         mock_request.get(url_get_statuses_for_ru_ref, status_code=404)
@@ -101,7 +101,7 @@ class TestReportingUnits(unittest.TestCase):
     def test_should_update_status_to_completed_by_phone(self, mock_request):
         # Given
         mock_request.get(url_get_party_by_ru_ref, json=party_business)
-        mock_request.get(url_get_cases_by_business_id, json=case_list)
+        mock_request.get(url_get_case_groups_by_business_id, json=case_group_list)
         mock_request.get(url_get_survey_by_short_name, json=self.survey)
         mock_request.get(url_get_collection_exercises_by_survey, json=collection_exercises)
         mock_request.put(url_update_status_for_ru_ref,
@@ -118,7 +118,7 @@ class TestReportingUnits(unittest.TestCase):
     def test_should_return_api_error_code_when_update_status_fails(self, mock_request):
         # Given
         mock_request.get(url_get_party_by_ru_ref, json=party_business)
-        mock_request.get(url_get_cases_by_business_id, json=case_list)
+        mock_request.get(url_get_case_groups_by_business_id, json=case_group_list)
         mock_request.get(url_get_survey_by_short_name, json=self.survey)
         mock_request.get(url_get_collection_exercises_by_survey, json=collection_exercises)
         mock_request.put(url_update_status_for_ru_ref, status_code=503)

--- a/test/resources/test_reporting_units.py
+++ b/test/resources/test_reporting_units.py
@@ -35,6 +35,9 @@ with open('test/test_data/collection_exercise/collection_exercise.json') as json
 url_get_iac_by_code = f'{app.config["RM_IAC_SERVICE"]}iacs/jkbvyklkwj88'
 with open('test/test_data/iac_details.json') as json_data:
     iac_details = json.load(json_data)
+url_get_case_groups_by_business_id = f'{app.config["RM_CASE_SERVICE"]}casegroups/partyid/b3ba864b-7cbc-4f44-84fe-88dc018a1a4c'
+with open('test/test_data/case/case_groups.json') as json_data:
+    case_group_list = json.load(json_data)
 
 
 class TestReportingUnits(unittest.TestCase):
@@ -68,6 +71,7 @@ class TestReportingUnits(unittest.TestCase):
         mock_request.get(url_get_party_by_ru_ref, json=party_business)
         mock_request.get(url_get_collection_exercises_by_party, json=collection_exercise_list)
         mock_request.get(url_get_cases_by_business_id, json=case_list)
+        mock_request.get(url_get_case_groups_by_business_id, json=case_group_list)
         mock_request.get(url_get_party_by_business_id, json=party_business)
         mock_request.get(url_get_survey_by_id, json=survey_list[0])
         mock_request.get(url_get_party_by_respondent_id, json=party_respondent)
@@ -86,6 +90,7 @@ class TestReportingUnits(unittest.TestCase):
         mock_request.get(url_get_party_by_ru_ref, json=party_business)
         mock_request.get(url_get_collection_exercises_by_party, json=collection_exercise_list)
         mock_request.get(url_get_cases_by_business_id, status_code=404)
+        mock_request.get(url_get_case_groups_by_business_id, json=case_group_list)
         mock_request.get(url_get_party_by_business_id, json=party_business)
         mock_request.get(url_get_survey_by_id, json=survey_list[0])
         mock_request.get(url_get_party_by_respondent_id, json=party_respondent)
@@ -101,6 +106,7 @@ class TestReportingUnits(unittest.TestCase):
         mock_request.get(url_get_party_by_ru_ref, json=party_business)
         mock_request.get(url_get_collection_exercises_by_party, status_code=204)
         mock_request.get(url_get_cases_by_business_id, json=case_list)
+        mock_request.get(url_get_case_groups_by_business_id, json=case_group_list)
         mock_request.get(url_get_party_by_business_id, json=party_business)
         mock_request.get(url_get_survey_by_id, json=survey_list[0])
         mock_request.get(url_get_party_by_respondent_id, json=party_respondent)
@@ -136,6 +142,10 @@ class TestReportingUnits(unittest.TestCase):
     def test_get_reporting_unit_cases_fail(self, mock_request):
         mock_request.get(url_get_party_by_ru_ref, json=party_business)
         mock_request.get(url_get_collection_exercises_by_party, json=collection_exercise_list)
+        mock_request.get(url_get_case_groups_by_business_id, json=case_group_list)
+        mock_request.get(url_get_party_by_business_id, json=party_business)
+        mock_request.get(url_get_survey_by_id, json=survey_list[0])
+        mock_request.get(url_get_party_by_respondent_id, json=party_respondent)
         mock_request.get(url_get_cases_by_business_id, status_code=500)
 
         response = self.app.get("/backstage-api/v1/reporting-unit/12345")
@@ -149,6 +159,7 @@ class TestReportingUnits(unittest.TestCase):
         mock_request.get(url_get_party_by_ru_ref, json=party_business)
         mock_request.get(url_get_collection_exercises_by_party, json=collection_exercise_list)
         mock_request.get(url_get_cases_by_business_id, json=case_list)
+        mock_request.get(url_get_case_groups_by_business_id, json=case_group_list)
         mock_request.get(url_get_party_by_business_id, status_code=500)
 
         response = self.app.get("/backstage-api/v1/reporting-unit/12345")
@@ -162,6 +173,7 @@ class TestReportingUnits(unittest.TestCase):
         mock_request.get(url_get_party_by_ru_ref, json=party_business)
         mock_request.get(url_get_collection_exercises_by_party, json=collection_exercise_list)
         mock_request.get(url_get_cases_by_business_id, json=case_list)
+        mock_request.get(url_get_case_groups_by_business_id, json=case_group_list)
         mock_request.get(url_get_party_by_business_id, json=party_business)
         mock_request.get(url_get_survey_by_id, status_code=500)
 
@@ -176,6 +188,7 @@ class TestReportingUnits(unittest.TestCase):
         mock_request.get(url_get_party_by_ru_ref, json=party_business)
         mock_request.get(url_get_collection_exercises_by_party, json=collection_exercise_list)
         mock_request.get(url_get_cases_by_business_id, json=case_list)
+        mock_request.get(url_get_case_groups_by_business_id, json=case_group_list)
         mock_request.get(url_get_party_by_business_id, json=party_business)
         mock_request.get(url_get_survey_by_id, json=survey_list[0])
         mock_request.get(url_get_party_by_respondent_id, status_code=500)
@@ -191,6 +204,7 @@ class TestReportingUnits(unittest.TestCase):
         mock_request.get(url_get_party_by_ru_ref, json=party_business)
         mock_request.get(url_get_collection_exercises_by_party, json=collection_exercise_list)
         mock_request.get(url_get_cases_by_business_id, json=case_list)
+        mock_request.get(url_get_case_groups_by_business_id, json=case_group_list)
         mock_request.get(url_get_party_by_business_id, json=party_business)
         mock_request.get(url_get_survey_by_id, json=survey_list[0])
         mock_request.get(url_get_party_by_respondent_id, json=party_respondent)

--- a/test/test_data/case/case_groups.json
+++ b/test/test_data/case/case_groups.json
@@ -1,0 +1,18 @@
+[
+  {
+      "collectionExerciseId": "14fb3e68-4dca-46db-bf49-04b84e07e77c",
+      "id": "612f5c34-7e11-4740-8e24-cb321a86a917",
+      "partyId": "cc1a1dc2-89a8-486f-9b9b-0fcfb3d33196",
+      "sampleUnitRef": "49900000001",
+      "sampleUnitType": "B",
+      "caseGroupStatus": "NOTSTARTED"
+  },
+  {
+      "collectionExerciseId": "9af403f8-5fc5-43b1-9fca-afbd9c65da5c",
+      "id": "f68c70d6-4a30-48bf-9c35-0202d3c2893f",
+      "partyId": "cc1a1dc2-89a8-486f-9b9b-0fcfb3d33196",
+      "sampleUnitRef": "49900000001",
+      "sampleUnitType": "B",
+      "caseGroupStatus": "NOTSTARTED"
+    }
+]


### PR DESCRIPTION
Recreate bug:
1) `make up` ras-rm-docker-dev repo
2) run acceptance tests from rasrm-acceptance-tests repo
3) Use response operations UI to execute Bricks 201802 `http://localhost:8085/surveys/Bricks/201802`:
      - Load a collection Instrument
      - Load sample file (rasrm-acceptance-tests/resources/sample_files/business-survey-sample-date.csv)
      - Click 'set as ready for live' button at the top of the page'
4) You will see a 500 server error when you try to visit a reporting units page `http://localhost:8085/reporting-units/49900000002`

Test changes fixes bug:
1) Build docker image of this branch `docker build . -t sdcplatform/ras-backstage:latest`
2) `mvn clean install` with branch: https://github.com/ONSdigital/rm-case-service/pull/22
3) `make up` ras-rm-docker-dev repo
4) You should now be able to visit a reporting unit page without any errors 