### PR TITLE
Quick fix

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@ import os
 class Config(object):
     DEBUG = os.getenv('DEBUG', False)
     TESTING = False
-    VERSION = os.getenv('VERSION', '0.1.0')
+    VERSION = os.getenv('VERSION', '0.1.1')
     PORT = os.getenv('PORT', 8001)
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'INFO')
     SECURITY_USER_NAME = os.getenv('SECURITY_USER_NAME')

--- a/ras_backstage/controllers/case_controller.py
+++ b/ras_backstage/controllers/case_controller.py
@@ -32,7 +32,7 @@ def filter_statuses(current_status, statuses):
         'INPROGRESS': ['COMPLETEDBYPHONE'],
         'REOPENED': ['COMPLETEDBYPHONE']
     }
-    allowed_transitions = manual_transisitions.get(current_status)
+    allowed_transitions = manual_transisitions.get(current_status, [])
     return {event: status for event, status in statuses.items() if status in allowed_transitions}
 
 


### PR DESCRIPTION
Quick fix to stop ru details page falling over, it does not fix the bug completely the side effect is you will not see the correct status for a collection exercise on the ru details page. This has been completely fixed in the master branch (ras-backstage and rm-case-service).