### PR TITLE
Send CI classifiers with single CE details

### DIFF
--- a/ras_backstage/controllers/collection_instrument_controller.py
+++ b/ras_backstage/controllers/collection_instrument_controller.py
@@ -10,13 +10,13 @@ from ras_backstage.exception.exceptions import ApiError
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-def upload_collection_instrument(collection_exercise_id, file):
+def upload_collection_instrument(collection_exercise_id, file, params=None):
     logger.debug('Uploading collection instrument', collection_exercise_id=collection_exercise_id)
     url = f'{app.config["RAS_COLLECTION_INSTRUMENT_SERVICE"]}' \
           f'collection-instrument-api/1.0.2/upload/{collection_exercise_id}'
 
     files = {"file": (file.filename, file.stream, file.mimetype)}
-    response = request_handler(url=url, method='POST', auth=app.config['BASIC_AUTH'], files=files)
+    response = request_handler(url=url, method='POST', auth=app.config['BASIC_AUTH'], files=files, params=params)
 
     if response.status_code != 200:
         logger.error('Error uploading collection instrument')

--- a/ras_backstage/controllers/survey_controller.py
+++ b/ras_backstage/controllers/survey_controller.py
@@ -68,6 +68,7 @@ def get_survey_ci_classifier(survey_id):
     for selector in classifier_type_selectors:
         if selector['name'] == "COLLECTION_INSTRUMENT":
             ci_selector = selector
+            break
 
     logger.debug('Retrieving classifiers for CI selector type', survey_id=survey_id, ci_selector=ci_selector['id'])
     url = f'{app.config["RM_SURVEY_SERVICE"]}surveys/{survey_id}/classifiertypeselectors/{ci_selector["id"]}'

--- a/ras_backstage/controllers/survey_controller.py
+++ b/ras_backstage/controllers/survey_controller.py
@@ -50,3 +50,35 @@ def get_survey_by_shortname(short_name):
 
     logger.debug('Successfully retrieved survey', short_name=short_name)
     return response.json()
+
+
+def get_survey_ci_classifier(survey_id):
+    logger.debug('Retrieving classifier type selectors', survey_id=survey_id)
+    url = f'{app.config["RM_SURVEY_SERVICE"]}surveys/{survey_id}/classifiertypeselectors'
+    response = request_handler('GET', url, auth=app.config['BASIC_AUTH'])
+
+    if response.status_code != 200:
+        logger.error('Error classifier type selectors', survey_id=survey_id)
+        raise ApiError(url, response.status_code)
+
+    logger.debug('Successfully retrieved classifier type selectors', survey_id=survey_id)
+
+    classifier_type_selectors = response.json()
+    ci_selector = None
+    for selector in classifier_type_selectors:
+        if selector['name'] == "COLLECTION_INSTRUMENT":
+            ci_selector = selector
+
+    logger.debug('Retrieving classifiers for CI selector type', survey_id=survey_id, ci_selector=ci_selector['id'])
+    url = f'{app.config["RM_SURVEY_SERVICE"]}surveys/{survey_id}/classifiertypeselectors/{ci_selector["id"]}'
+    response = request_handler('GET', url, auth=app.config['BASIC_AUTH'])
+
+    if response.status_code != 200:
+        logger.error('Error retrieving classifiers for CI selector type', survey_id=survey_id,
+                     ci_selector=ci_selector['id'])
+        raise ApiError(url, response.status_code)
+
+    logger.debug('Successfully retrieved classifiers for CI selector type', survey_id=survey_id,
+                 ci_selector=ci_selector['id'])
+
+    return response.json()

--- a/ras_backstage/resources/collection_exercise/single_collection_exercise.py
+++ b/ras_backstage/resources/collection_exercise/single_collection_exercise.py
@@ -42,13 +42,16 @@ class GetSingleCollectionExercise(Resource):
         summary_id = collection_exercise_controller.get_linked_sample_summary_id(exercise['id'])
         sample_summary = sample_controller.get_sample_summary(summary_id) if summary_id else None
 
+        ci_classifiers = survey_controller.get_survey_ci_classifier(survey['id'])
+
         response_json = {
             "survey": survey,
             "collection_exercise": full_exercise,
             "events": exercise_events,
             "collection_instruments": collection_instruments,
             "eq_ci_selectors": eq_ci_selectors,
-            "sample_summary": sample_summary
+            "sample_summary": sample_summary,
+            "ci_classifiers": ci_classifiers
         }
         logger.info('Successfully retrieved collection exercise details',
                     shortname=short_name, period=period)

--- a/ras_backstage/resources/collection_instrument/collection_instrument.py
+++ b/ras_backstage/resources/collection_instrument/collection_instrument.py
@@ -30,7 +30,7 @@ class CollectionInstrument(Resource):
         if not exercise:
             return make_response(jsonify({"message": "Collection exercise not found"}), 404)
 
-        upload_collection_instrument(exercise['id'], request.files['file'])
+        upload_collection_instrument(exercise['id'], request.files['file'], request.args)
 
         logger.info('Successfully uploaded collection instrument', shortname=short_name, period=period)
         return Response(status=201)

--- a/ras_backstage/resources/collection_instrument/collection_instrument.py
+++ b/ras_backstage/resources/collection_instrument/collection_instrument.py
@@ -14,6 +14,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 parser = reqparse.RequestParser()
 parser.add_argument('file', location='files', required=True)
+parser.add_argument('classifiers', location='args')
 
 
 @collection_instrument_api.route('/<short_name>/<period>')

--- a/test/test_data/survey/classifier_type_selectors.json
+++ b/test/test_data/survey/classifier_type_selectors.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "efa868fb-fb80-44c7-9f33-d6800a17c4da",
+    "name": "COLLECTION_INSTRUMENT"
+  },
+  {
+    "id": "e119ffd6-6fc1-426c-ae81-67a96f9a71ba",
+    "name": "COMMUNICATION_TEMPLATE"
+  }
+]

--- a/test/test_data/survey/classifier_types.json
+++ b/test/test_data/survey/classifier_types.json
@@ -1,0 +1,7 @@
+{
+  "id": "efa868fb-fb80-44c7-9f33-d6800a17c4da",
+  "name": "COLLECTION_INSTRUMENT",
+  "classifierTypes": [
+    "FORM_TYPE"
+  ]
+}


### PR DESCRIPTION
This PR passes the CI classifiers along with the CE details so the response operations can carry out the correct checks for an uploaded CI depending on the CI classifier.