### PR TITLE
Update the update message label endpoint to V2

### DIFF
--- a/ras_backstage/__init__.py
+++ b/ras_backstage/__init__.py
@@ -68,7 +68,7 @@ from ras_backstage.resources.sample.sample import Sample  # NOQA # pylint: disab
 from ras_backstage.resources.secure_messaging.get_message_list import GetMessagesList  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.secure_messaging.get_message import GetMessage  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.secure_messaging.get_thread_list import GetThreadsList  # NOQA # pylint: disable=wrong-import-position
-from ras_backstage.resources.secure_messaging.update_label import RemoveUnreadLabel  # NOQA # pylint: disable=wrong-import-position
+from ras_backstage.resources.secure_messaging.update_label import UpdateLabel  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.secure_messaging.send_message import SendMessage  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.secure_messaging.save_draft import SaveDraft  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.secure_messaging.get_thread import GetThread  # NOQA # pylint: disable=wrong-import-position

--- a/ras_backstage/controllers/secure_messaging_controller.py
+++ b/ras_backstage/controllers/secure_messaging_controller.py
@@ -89,7 +89,7 @@ def get_thread_by_id(encoded_jwt, thread_id):
 
 def update_label(encoded_jwt, message_id, label, action):
     logger.debug('Updating label', message_id=message_id, label=label, action=action)
-    url = f"{app.config['RAS_SECURE_MESSAGING_SERVICE']}message/{message_id}/modify"
+    url = f"{app.config['RAS_SECURE_MESSAGING_SERVICE']}v2/messages/modify/{message_id}"
     headers = _create_authorization_header(encoded_jwt)
     data = {"label": label, "action": action}
     response = request_handler('PUT', url, headers=headers, json=data)

--- a/ras_backstage/resources/reporting_units/get_reporting_unit.py
+++ b/ras_backstage/resources/reporting_units/get_reporting_unit.py
@@ -68,7 +68,9 @@ def add_collection_exercise_details(collection_exercises, reporting_unit, case_g
         reporting_unit_ce = party_controller.get_party_by_business_id(reporting_unit['id'], exercise['id'])
         exercise['companyName'] = reporting_unit_ce['name']
         exercise['companyRegion'] = reporting_unit_ce['region']
-        exercise['tradingAs'] = f"{reporting_unit_ce['tradstyle1']} {reporting_unit_ce['tradstyle2']} {reporting_unit_ce['tradstyle3']}"
+        exercise['tradingAs'] = (f"{reporting_unit_ce['tradstyle1']} "
+                                 f"{reporting_unit_ce['tradstyle2']} "
+                                 f"{reporting_unit_ce['tradstyle3']}")
 
 
 def link_respondents_to_survey(respondents, survey, ru_ref):

--- a/ras_backstage/resources/secure_messaging/update_label.py
+++ b/ras_backstage/resources/secure_messaging/update_label.py
@@ -18,7 +18,7 @@ label_details = secure_messaging_api.model('LabelDetails', {
 
 
 @secure_messaging_api.route('/update-label/<message_id>')
-class RemoveUnreadLabel(Resource):
+class UpdateLabel(Resource):
     method_decorators = [get_jwt(request)]
 
     @staticmethod

--- a/test/resources/test_secure_messaging.py
+++ b/test/resources/test_secure_messaging.py
@@ -15,7 +15,8 @@ with open('test/test_data/secure_messaging/messages_list.json') as json_data:
 url_get_threads = f"{app.config['RAS_SECURE_MESSAGING_SERVICE']}threads?limit=1000"
 with open('test/test_data/secure_messaging/threads_list.json') as json_data:
     threads_list = json.load(json_data)
-url_update_label = f"{app.config['RAS_SECURE_MESSAGING_SERVICE']}message/dfcb2b2c-a1d8-4d86-a974-7ffe05a3141b/modify"
+url_update_label = (f"{app.config['RAS_SECURE_MESSAGING_SERVICE']}"
+                    f"v2/messages/modify/dfcb2b2c-a1d8-4d86-a974-7ffe05a3141b")
 url_send_message = f"{app.config['RAS_SECURE_MESSAGING_SERVICE']}v2/messages"
 url_save_draft = f"{app.config['RAS_SECURE_MESSAGING_SERVICE']}draft/save"
 url_modify_draft = f"{app.config['RAS_SECURE_MESSAGING_SERVICE']}draft/test_msg_id/modify"


### PR DESCRIPTION
Changes the secure message end point that is used to update the message labels to the v2 version.
Also renames the class as the previous name was misleading, it could do more than just remove the unread label on a message.

Also minor unrelated linting fixes necessary to run `make test` successfully.

**How to test:**
There is a branch of response-operations-ui that uses this endpoint:
[Response Operations UI: SM114/distinguish unread messages](https://github.com/ONSdigital/response-operations-ui/tree/sm114/distinguish-unread-messages)

And try opening an unread message in the secure message inbox.