### PR TITLE
Defect-R17_2-Pass collection_exercise_id to party service when uploading sample

### DIFF
--- a/ras_backstage/controllers/sample_controller.py
+++ b/ras_backstage/controllers/sample_controller.py
@@ -31,8 +31,9 @@ def upload_sample(collection_exercise_id, sample_file, survey_type='B'):
                  collection_exercise_id=collection_exercise_id,
                  survey_type=survey_type)
     url = f'{app.config["RM_SAMPLE_SERVICE"]}samples/{survey_type}/fileupload'
-
-    response = request_handler(url=url, method='POST', auth=app.config['BASIC_AUTH'], files={'file': sample_file})
+    params = {"collectionExerciseId": collection_exercise_id}
+    response = request_handler(url=url, method='POST', auth=app.config['BASIC_AUTH'],
+                               files={'file': sample_file}, params=params)
 
     # Sample service *should* return something other than 201 when upload / ingest fails
     if response.status_code != 201:


### PR DESCRIPTION
Pass `collection_exercise_id` to sample service in the query string

Works with other PR's
https://github.com/ONSdigital/rm-collection-exercise-service/pull/43
https://github.com/ONSdigital/ras-party/pull/119
https://github.com/ONSdigital/rm-party-service-api/pull/10
https://github.com/ONSdigital/rm-sample-service/pull/25

[Trello](https://trello.com/c/nakcH70j/161-defect-r172-if-the-business-name-is-updated-in-a-sample-for-the-next-period-it-is-historically-updating-the-business-name-for-pr)