### PR TITLE
US091 Find respondent by email

### DIFF
--- a/ras_backstage/__init__.py
+++ b/ras_backstage/__init__.py
@@ -58,7 +58,8 @@ from ras_backstage.resources.collection_instrument.collection_instrument import 
 from ras_backstage.resources.collection_instrument.link_exercise import LinkExercise  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.info import Info  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.party.get_party_details import PartyDetails  # NOQA # pylint: disable=wrong-import-position
-from ras_backstage.resources.party.update_respondent_details import UpdateRespondentDetails # NOQA # pylint: disable=wrong-import-position
+from ras_backstage.resources.party.get_respondent_by_email import RespondentByEmail  # NOQA # pylint: disable=wrong-import-position
+from ras_backstage.resources.party.update_respondent_details import UpdateRespondentDetails  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.reporting_units.get_reporting_unit import GetReportingUnit  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.reporting_units.generate_new_enrolment_code import GenerateNewEnrolmentCode  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.case.reporting_unit_case_group_status import ReportingUnitCaseGroupStatus  # NOQA # pylint: disable=wrong-import-position

--- a/ras_backstage/common/requests_handler.py
+++ b/ras_backstage/common/requests_handler.py
@@ -19,7 +19,7 @@ def request_handler(method, url, params=None, auth=None, headers=None, json=None
             response = requests.put(url, params=params, auth=auth, headers=headers,
                                     json=json, data=data, files=files)
         else:
-            response = requests.get(url, params=params, auth=auth, headers=headers)
+            response = requests.get(url, params=params, auth=auth, headers=headers, json=json)
     except RequestException as e:
         logger.exception('Failed to connect to external service',
                          method=method, url=url, exception=str(e))

--- a/ras_backstage/controllers/party_controller.py
+++ b/ras_backstage/controllers/party_controller.py
@@ -94,3 +94,19 @@ def resend_verification_email(party_id):
         raise ApiError(url=url, status_code=response.status_code)
 
     logger.debug('Successfully resent verification email')
+
+
+def get_respondent_by_email(email):
+    logger.debug('Getting respondent by email')
+    url = f'{app.config["RAS_PARTY_SERVICE"]}party-api/v1/respondents/email'
+
+    response = request_handler('GET', url, json=email, auth=app.config['BASIC_AUTH'])
+
+    if response.status_code != 200:
+        if response.status_code == 404:
+            return {"Response": "No respondent found"}
+        else:
+            logger.error('Error retrieving respondent')
+            raise ApiError(url, response.status_code)
+
+    return response.json()

--- a/ras_backstage/controllers/party_controller.py
+++ b/ras_backstage/controllers/party_controller.py
@@ -102,11 +102,10 @@ def get_respondent_by_email(email):
 
     response = request_handler('GET', url, json=email, auth=app.config['BASIC_AUTH'])
 
-    if response.status_code != 200:
-        if response.status_code == 404:
-            return {"Response": "No respondent found"}
-        else:
-            logger.error('Error retrieving respondent')
-            raise ApiError(url, response.status_code)
+    if response.status_code == 404:
+        return {"Response": "No respondent found"}
+    elif response.status_code != 200:
+        logger.error('Error retrieving respondent')
+        raise ApiError(url, response.status_code)
 
     return response.json()

--- a/ras_backstage/controllers/party_controller.py
+++ b/ras_backstage/controllers/party_controller.py
@@ -103,9 +103,10 @@ def get_respondent_by_email(email):
     response = request_handler('GET', url, json=email, auth=app.config['BASIC_AUTH'])
 
     if response.status_code == 404:
+        logger.debug("No respondent found")
         return {"Response": "No respondent found"}
     elif response.status_code != 200:
         logger.error('Error retrieving respondent')
         raise ApiError(url, response.status_code)
-
+    logger.debug("Successfully retrieved respondent")
     return response.json()

--- a/ras_backstage/controllers/party_controller.py
+++ b/ras_backstage/controllers/party_controller.py
@@ -103,7 +103,7 @@ def get_respondent_by_email(email):
     response = request_handler('GET', url, json=email, auth=app.config['BASIC_AUTH'])
 
     if response.status_code == 404:
-        logger.debug("No respondent found")
+        logger.debug("No respondent found", status_code=response.status_code)
         return {"Response": "No respondent found"}
     elif response.status_code != 200:
         logger.error('Error retrieving respondent')

--- a/ras_backstage/resources/party/get_respondent_by_email.py
+++ b/ras_backstage/resources/party/get_respondent_by_email.py
@@ -21,7 +21,7 @@ class RespondentByEmail(Resource):
     @staticmethod
     @party_api.expect(respondent_email, validate=True)
     def get():
-        logger.info('Get responddent by email')
+        logger.info('Get respondent by email')
         email = request.get_json()
         response = party_controller.get_respondent_by_email(email)
 

--- a/ras_backstage/resources/party/get_respondent_by_email.py
+++ b/ras_backstage/resources/party/get_respondent_by_email.py
@@ -1,0 +1,30 @@
+import logging
+
+from flask import jsonify, make_response, request
+from flask_restplus import fields, Resource
+from structlog import wrap_logger
+
+from ras_backstage import party_api
+from ras_backstage.controllers import party_controller
+
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+respondent_email = party_api.model('RespondentEmail', {
+    'email': fields.String(required=True)
+})
+
+
+@party_api.route('/get-respondent-by-email')
+class RespondentByEmail(Resource):
+
+    @staticmethod
+    @party_api.expect(respondent_email, validate=True)
+    def get():
+        logger.info('Get responddent by email')
+        email = request.get_json()
+        response = party_controller.get_respondent_by_email(email)
+
+        logger.info("Successfully retrieved respondent by email")
+
+        return make_response(jsonify(response), 200)


### PR DESCRIPTION
Add functionality to find respondent by email. This works with Response-operations-ui and ras-party changes as well. Currently working on unit tests.