### PR TITLE
Fix multiple surveys secure message

### DIFF
--- a/ras_backstage/resources/reporting_units/get_reporting_unit.py
+++ b/ras_backstage/resources/reporting_units/get_reporting_unit.py
@@ -69,8 +69,8 @@ def add_collection_exercise_details(collection_exercises, reporting_unit, case_g
         exercise['companyName'] = reporting_unit_ce['name']
         exercise['companyRegion'] = reporting_unit_ce['region']
         exercise['tradingAs'] = f"{reporting_unit_ce['tradstyle1']}" \
-                                f"{reporting_unit_ce['tradstyle2']} " \
-                                f"{reporting_unit_ce['tradstyle3']}"
+                                f" {reporting_unit_ce['tradstyle2']}" \
+                                f" {reporting_unit_ce['tradstyle3']}"
 
 
 def link_respondents_to_survey(respondents, survey, ru_ref):

--- a/ras_backstage/resources/reporting_units/get_reporting_unit.py
+++ b/ras_backstage/resources/reporting_units/get_reporting_unit.py
@@ -68,7 +68,9 @@ def add_collection_exercise_details(collection_exercises, reporting_unit, case_g
         reporting_unit_ce = party_controller.get_party_by_business_id(reporting_unit['id'], exercise['id'])
         exercise['companyName'] = reporting_unit_ce['name']
         exercise['companyRegion'] = reporting_unit_ce['region']
-        exercise['tradingAs'] = f"{reporting_unit_ce['tradstyle1']} {reporting_unit_ce['tradstyle2']} {reporting_unit_ce['tradstyle3']}"
+        exercise['tradingAs'] = f"{reporting_unit_ce['tradstyle1']}" \
+                                f"{reporting_unit_ce['tradstyle2']} " \
+                                f"{reporting_unit_ce['tradstyle3']}"
 
 
 def link_respondents_to_survey(respondents, survey, ru_ref):

--- a/ras_backstage/resources/secure_messaging/get_thread_list.py
+++ b/ras_backstage/resources/secure_messaging/get_thread_list.py
@@ -27,7 +27,7 @@ class GetThreadsList(Resource):
     def get(encoded_jwt):
         message_args = {
             'limit': request.args.get('limit', 1000),
-            'survey': request.args.get('survey')
+            'survey': request.args.getlist('survey')
         }
 
         logger.info('Retrieving threads list')


### PR DESCRIPTION
Filtering threads by multiple surveys (as required for FDI) was not working, this change fixes the issue.

Dependent on this branch of secure-message:
[Secure Message: Fix filtering by multiple survey](https://github.com/ONSdigital/ras-secure-message/pull/184
)

**How to review:**
Try hitting the get threads list endpoint with multiple surveys in the parameters (can by done through response-operations-ui by selecting the FDI survey filter), backstage should now pass all the surveys to secure-message where before it was only passing the first.

Requires this fix branch of secure-message for the feature to work:
[Secure Message: Fix filtering by multiple survey](https://github.com/ONSdigital/ras-secure-message/pull/184
)