### PR TITLE
Us022 disable enrolment status

### DIFF
--- a/ras_backstage/__init__.py
+++ b/ras_backstage/__init__.py
@@ -58,6 +58,7 @@ from ras_backstage.resources.collection_exercise.update_collection_exercise_deta
 from ras_backstage.resources.collection_instrument.collection_instrument import CollectionInstrument  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.collection_instrument.link_exercise import LinkExercise  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.info import Info  # NOQA # pylint: disable=wrong-import-position
+from ras_backstage.resources.party.change_enrolment_status import ChangeEnrolmentStatus
 from ras_backstage.resources.party.get_party_details import PartyDetails  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.party.get_respondent_by_email import RespondentByEmail  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.party.update_respondent_details import UpdateRespondentDetails  # NOQA # pylint: disable=wrong-import-position

--- a/ras_backstage/controllers/party_controller.py
+++ b/ras_backstage/controllers/party_controller.py
@@ -74,3 +74,15 @@ def resend_verification_email(party_id):
         raise ApiError(url=url, status_code=response.status_code)
 
     logger.debug('Successfully resent verification email')
+
+
+def put_respondent_enrolment_status(enrolment):
+    logger.debug('Changing enrolment status', enrolment=enrolment)
+    url = f'{app.config["RAS_PARTY_SERVICE"]}party-api/v1/respondents/change_enrolment_status'
+    response = request_handler('PUT', url, auth=app.config['BASIC_AUTH'], json=enrolment)
+
+    if response.status_code != 200:
+        logger.error('Failed to change enrolment status', enrolment=enrolment)
+        raise ApiError(url=url, status_code=response.status_code)
+
+    logger.debug('Successfully changed enrolment status')

--- a/ras_backstage/resources/party/change_enrolment_status.py
+++ b/ras_backstage/resources/party/change_enrolment_status.py
@@ -10,8 +10,8 @@ from ras_backstage.controllers import party_controller
 logger = wrap_logger(logging.getLogger(__name__))
 
 enrolment_details = party_api.model('EnrolmentDetails', {
-    'respondent_party_id': fields.String(required=True),
-    'business_party_id': fields.String(required=True),
+    'respondent_id': fields.String(required=True),
+    'business_id': fields.String(required=True),
     'survey_id': fields.String(required=True),
     'change_flag': fields.String(required=True)
 }

--- a/ras_backstage/resources/party/change_enrolment_status.py
+++ b/ras_backstage/resources/party/change_enrolment_status.py
@@ -14,8 +14,7 @@ enrolment_details = party_api.model('EnrolmentDetails', {
     'business_id': fields.String(required=True),
     'survey_id': fields.String(required=True),
     'change_flag': fields.String(required=True)
-}
-)
+})
 
 
 @party_api.route('/change-enrolment-status')

--- a/ras_backstage/resources/party/change_enrolment_status.py
+++ b/ras_backstage/resources/party/change_enrolment_status.py
@@ -1,0 +1,33 @@
+import logging
+
+from flask import jsonify, make_response, request
+from flask_restplus import fields, Resource
+from structlog import wrap_logger
+
+from ras_backstage import party_api
+from ras_backstage.controllers import party_controller
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+enrolment_details = party_api.model('EnrolmentDetails', {
+    'respondent_party_id': fields.String(required=True),
+    'business_party_id': fields.String(required=True),
+    'survey_id': fields.String(required=True),
+    'change_flag': fields.String(required=True)
+}
+)
+
+
+@party_api.route('/change-enrolment-status')
+class ChangeEnrolmentStatus(Resource):
+
+    @staticmethod
+    @party_api.expect(enrolment_details, validate=True)
+    def put():
+        enrolment_json = request.get_json()
+        logger.info('Changing respondent enrolment status')
+
+        response = party_controller.put_respondent_enrolment_status(enrolment_json)
+
+        logger.info('Successfully changed enrolment status')
+        return make_response(jsonify(response), 200)

--- a/test/resources/test_change_enrolment_status.py
+++ b/test/resources/test_change_enrolment_status.py
@@ -1,0 +1,50 @@
+import json
+import unittest
+
+import requests_mock
+
+from ras_backstage import app
+
+
+url_change_enrolment_status = f'{app.config["RAS_PARTY_SERVICE"]}party-api/v1/respondents/change_enrolment_status'
+
+
+class TestChangeEnrolmentStatus(unittest.TestCase):
+
+    def setUp(self):
+        self.app = app.test_client()
+        self.enrolment_details = {
+            'respondent_id': 'test_id',
+            'business_id': 'test_id',
+            'survey_id': 'test_id',
+            'change_flag': 'RESPONDENT_ENROLMENT_DISABLED'
+        }
+        self.headers = {
+            'Content-Type': 'application/json',
+        }
+
+    @requests_mock.mock()
+    def test_change_enrolment_status(self, mock_request):
+        mock_request.put(url_change_enrolment_status)
+
+        response = self.app.put("/backstage-api/v1/party/change-enrolment-status", headers=self.headers,
+                                data=json.dumps(self.enrolment_details))
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_change_enrolment_status_bad_request(self):
+        response = self.app.put("/backstage-api/v1/party/change-enrolment-status", headers=self.headers,
+                                data=json.dumps({"bad": "Json"}))
+
+        self.assertEqual(response.status_code, 400)
+
+    @requests_mock.mock()
+    def test_change_enrolment_status_fail(self, mock_request):
+        mock_request.put(url_change_enrolment_status, status_code=500)
+
+        response = self.app.put("/backstage-api/v1/party/change-enrolment-status", headers=self.headers,
+                                data=json.dumps(self.enrolment_details))
+        response_data = json.loads(response.data)
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response_data['error']['status_code'], 500)


### PR DESCRIPTION
Added endpoint for updating a respondents enrolment status for a survey.

This brought up a bug in returning the enrolment status to the UI on the reporting unit page. We were editing a single dictionary a large number of times to create the response and the status was being overridden when there was more than one survey. Things have been made more functional with list comprehensions to prevent this.

Works with other PR's:
[response-operations-ui](https://github.com/ONSdigital/response-operations-ui/pull/123)
[ras-party]()
[rm-case]()
[rm-casesvc-api]()

[Confluence](https://digitaleq.atlassian.net/wiki/spaces/RASB/pages/248545529/US022+Disable+respondent+enrolment+to+a+survey)
[Trello](https://trello.com/c/1ez85L0y/51-us022-int-disable-respondents-enrolment-to-a-survey-l)