### PR TITLE
Us102 create collection exercise

### DIFF
--- a/ras_backstage/__init__.py
+++ b/ras_backstage/__init__.py
@@ -52,6 +52,7 @@ api.add_namespace(survey_api)
 import ras_backstage.error_handlers  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.collection_exercise.single_collection_exercise import GetSingleCollectionExercise, ExecuteSingleCollectionExercise  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.collection_exercise.update_collection_exercise_details import UpdateCollectionExerciseDetails  # NOQA # pylint: disable=wrong-import-position
+from ras_backstage.resources.collection_exercise.create_collection_exercise import CreateCollectionExercise # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.collection_exercise.collection_exercise_events import CollectionExerciseEvents  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.collection_exercise.collection_exercise_events import CollectionExerciseEvent  # NOQA # pylint: disable=wrong-import-position
 from ras_backstage.resources.collection_instrument.collection_instrument import CollectionInstrument  # NOQA # pylint: disable=wrong-import-position

--- a/ras_backstage/controllers/collection_exercise_controller.py
+++ b/ras_backstage/controllers/collection_exercise_controller.py
@@ -191,19 +191,25 @@ def update_collection_exercise_period(collection_exercise_id, period):
     logger.debug('Successfully updated collection exercise period', collection_exercise_id=collection_exercise_id)
 
 
-def create_collection_exercise(collection_exercise_id, user_description, period):
-    logger.debug('Creating new collection exercise', collection_exercise_id=collection_exercise_id,
-                 period=period, user_description=user_description)
-    header = {'Content-Type': "text/plain"}
-    url = f'{app.config["RM_COLLECTION_EXERCISE_SERVICE"]}' \
-          f'collectionexercises/{collection_exercise_id}/create-collection-exercise'
-    response = request_handler('POST', url, headers=header, data=period, auth=app.config['BASIC_AUTH'])
+def create_collection_exercise(created_collection_exercise_details):
+    logger.debug('Creating new collection exercise')
+    header = {'Content-Type': "application/json"}
+    url = f'{app.config["RM_COLLECTION_EXERCISE_SERVICE"]}collectionexercises'
+
+    payload = {
+        "surveyId": created_collection_exercise_details['survey_id'],
+        "name": created_collection_exercise_details['survey_name'],
+        "userDescription": created_collection_exercise_details['user_description'],
+        "exerciseRef": created_collection_exercise_details['period']
+    }
+
+    response = request_handler('POST', url, json=payload, headers=header, auth=app.config['BASIC_AUTH'])
 
     if response.status_code == 404:
-        logger.error('Error retrieving new collection exercise data', collection_exercise_id=collection_exercise_id)
+        logger.error('Error retrieving new collection exercise data')
         raise ApiError(url, response.status_code)
     if response.status_code not in (200, 201, 202):
-        logger.error('Error creating new collection exercise', collection_exercise_id=collection_exercise_id)
+        logger.error('Error creating new collection exercise')
         raise ApiError(url, response.status_code)
 
-    logger.debug('Successfully created a new collection exercise', collection_exercise_id=collection_exercise_id)
+    logger.debug('Successfully created a new collection exercise')

--- a/ras_backstage/controllers/collection_exercise_controller.py
+++ b/ras_backstage/controllers/collection_exercise_controller.py
@@ -205,3 +205,21 @@ def update_collection_exercise_period(collection_exercise_id, period):
         raise ApiError(url, response.status_code)
 
     logger.debug('Successfully updated collection exercise period', collection_exercise_id=collection_exercise_id)
+
+
+def create_collection_exercise(collection_exercise_id, user_description, period):
+    logger.debug('Creating new collection exercise', collection_exercise_id=collection_exercise_id,
+                 period=period, user_description=user_description)
+    header = {'Content-Type': "text/plain"}
+    url = f'{app.config["RM_COLLECTION_EXERCISE_SERVICE"]}' \
+          f'collectionexercises/{collection_exercise_id}/create-collection-exercise'
+    response = request_handler('POST', url, headers=header, data=period, auth=app.config['BASIC_AUTH'])
+
+    if response.status_code == 404:
+        logger.error('Error retrieving new collection exercise data', collection_exercise_id=collection_exercise_id)
+        raise ApiError(url, response.status_code)
+    if response.status_code not in (200, 201, 202):
+        logger.error('Error creating new collection exercise', collection_exercise_id=collection_exercise_id)
+        raise ApiError(url, response.status_code)
+
+    logger.debug('Successfully created a new collection exercise', collection_exercise_id=collection_exercise_id)

--- a/ras_backstage/resources/collection_exercise/create_collection_exercise.py
+++ b/ras_backstage/resources/collection_exercise/create_collection_exercise.py
@@ -10,23 +10,23 @@ from ras_backstage.controllers import collection_exercise_controller
 logger = wrap_logger(logging.getLogger(__name__))
 
 collection_exercise_details = collection_exercise_api.model('CollectionExerciseDetails', {
+    'survey_id': fields.String(required=True),
+    'survey_name': fields.String(required=True),
     'user_description': fields.String(required=True),
     'period': fields.String(required=True)
 })
 
 
-@collection_exercise_api.route('/create-collection-exercise/<collection_exercise_id>')
+@collection_exercise_api.route('/create-collection-exercise')
 class CreateCollectionExercise(Resource):
     @staticmethod
     @collection_exercise_api.expect(collection_exercise_details, validate=True)
-    def post(collection_exercise_id):
+    def post():
 
-        logger.info('Retrieving created collection exercise details', collection_exercise_id=collection_exercise_id)
-        user_description = request.json["user_description"]
-        period = request.json["period"]
+        logger.info('Retrieving created collection exercise details')
+        created_collection_exercise_details = request.get_json()
+        collection_exercise_controller.create_collection_exercise(created_collection_exercise_details)
 
-        collection_exercise_controller.create_collection_exercise(collection_exercise_id, user_description, period)
-
-        logger.info('Successfully created new collection exercise', collection_exercise_id=collection_exercise_id)
+        logger.info('Successfully created new collection exercise')
 
         return 200

--- a/ras_backstage/resources/collection_exercise/create_collection_exercise.py
+++ b/ras_backstage/resources/collection_exercise/create_collection_exercise.py
@@ -1,0 +1,32 @@
+import logging
+
+from flask import request
+from flask_restplus import Resource, fields
+from structlog import wrap_logger
+
+from ras_backstage import collection_exercise_api
+from ras_backstage.controllers import collection_exercise_controller
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+collection_exercise_details = collection_exercise_api.model('CollectionExerciseDetails', {
+    'user_description': fields.String(required=True),
+    'period': fields.String(required=True)
+})
+
+
+@collection_exercise_api.route('/create-collection-exercise/<collection_exercise_id>')
+class CreateCollectionExercise(Resource):
+    @staticmethod
+    @collection_exercise_api.expect(collection_exercise_details, validate=True)
+    def post(collection_exercise_id):
+
+        logger.info('Retrieving created collection exercise details', collection_exercise_id=collection_exercise_id)
+        user_description = request.json["user_description"]
+        period = request.json["period"]
+
+        collection_exercise_controller.create_collection_exercise(collection_exercise_id, user_description, period)
+
+        logger.info('Successfully created new collection exercise', collection_exercise_id=collection_exercise_id)
+
+        return 200

--- a/test/resources/test_collection_exercise.py
+++ b/test/resources/test_collection_exercise.py
@@ -34,6 +34,7 @@ url_update_ce_details_period = f'{app.config["RM_COLLECTION_EXERCISE_SERVICE"]}'
                         f'collectionexercises/{collection_exercise_id}/exerciseRef'
 url_get_collection_instrument = f'{app.config["RAS_COLLECTION_INSTRUMENT_SERVICE"]}' \
                                    f'collection-instrument-api/1.0.2/collectioninstrument'
+url_create_ce = f'{app.config["RM_COLLECTION_EXERCISE_SERVICE"]}collectionexercises'
 
 with open('test/test_data/collection_exercise/collection_exercise.json') as json_data:
     collection_exercise = json.load(json_data)
@@ -537,6 +538,42 @@ class TestCollectionExercise(unittest.TestCase):
         mock_request.put(url_update_ce_details_period, status_code=404)
         url = f'backstage-api/v1/collection-exercise/update-collection-exercise-details/{collection_exercise_id}'
         response = self.app.put(url, headers=self.headers, data=json.dumps({
+            "user_description": '',
+            "period": ''
+        }))
+        self.assertEqual(response.status_code, 404)
+
+    @requests_mock.mock()
+    def test_create_collection_exercise_success(self, mock_request):
+        mock_request.post(url_create_ce, status_code=200)
+        url = f'backstage-api/v1/collection-exercise/create-collection-exercise'
+        response = self.app.post(url, headers=self.headers, data=json.dumps({
+            "survey_id": 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
+            "survey_name": 'BRES',
+            "user_description": 'June 2018',
+            "period": '201806'
+        }))
+        self.assertEqual(response.status_code, 200)
+
+    @requests_mock.mock()
+    def test_create_collection_exercise_failure(self, mock_request):
+        mock_request.post(url_create_ce, status_code=500)
+        url = f'backstage-api/v1/collection-exercise/create-collection-exercise'
+        response = self.app.post(url, headers=self.headers, data=json.dumps({
+            "survey_id": 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
+            "survey_name": 'BRES',
+            "user_description": 'June 2018',
+            "period": '201806'
+        }))
+        self.assertEqual(response.status_code, 500)
+
+    @requests_mock.mock()
+    def test_create_collection_exercise_no_data(self, mock_request):
+        mock_request.post(url_create_ce, status_code=404)
+        url = f'backstage-api/v1/collection-exercise/create-collection-exercise'
+        response = self.app.post(url, headers=self.headers, data=json.dumps({
+            "survey_id": 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87',
+            "survey_name": 'BRES',
             "user_description": '',
             "period": ''
         }))


### PR DESCRIPTION
This PR allows for a user to create a new collection exercise with validation to ensure that a period cannot be entered if it already exists for a collection exercise for that survey.

Run alongside:

https://github.com/ONSdigital/response-operations-ui/pull/140

